### PR TITLE
FEAT: Allow multivalue for Config attibutes

### DIFF
--- a/docs/resources/custom_user_federation.md
+++ b/docs/resources/custom_user_federation.md
@@ -27,6 +27,7 @@ resource "keycloak_custom_user_federation" "custom_user_federation" {
   config = {
     dummyString = "foobar"
     dummyBool   = true
+    multivalue = "value1##value2"
   }
 }
 ```
@@ -42,7 +43,7 @@ resource "keycloak_custom_user_federation" "custom_user_federation" {
 - `parent_id` - (Optional) Must be set to the realms' `internal_id`  when it differs from the realm. This can happen when existing resources are imported into the state.
 - `full_sync_period` - (Optional) How frequently Keycloak should sync all users, in seconds. Omit this property to disable periodic full sync.
 - `changed_sync_period` - (Optional) How frequently Keycloak should sync changed users, in seconds. Omit this property to disable periodic changed users sync.
-- `config` - (Optional) The provider configuration handed over to your custom user federation provider.
+- `config` - (Optional) The provider configuration handed over to your custom user federation provider. In order to add multivalue settings, use `##` to seperate the values.
 
 ## Import
 

--- a/provider/resource_keycloak_custom_user_federation.go
+++ b/provider/resource_keycloak_custom_user_federation.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -95,9 +96,10 @@ func getCustomUserFederationFromData(data *schema.ResourceData, realmInternalId 
 	config := map[string][]string{}
 	if v, ok := data.GetOk("config"); ok {
 		for key, value := range v.(map[string]interface{}) {
-			config[key] = []string{value.(string)}
+			config[key] = strings.Split(value.(string), MULTIVALUE_ATTRIBUTE_SEPARATOR)
 		}
 	}
+
 	parentId := ""
 	dataParentId := data.Get("parent_id").(string)
 	if dataParentId != "" {
@@ -142,9 +144,9 @@ func setCustomUserFederationData(data *schema.ResourceData, custom *keycloak.Cus
 
 	data.Set("cache_policy", custom.CachePolicy)
 
-	config := make(map[string]interface{})
+	config := map[string]string{}
 	for k, v := range custom.Config {
-		config[k] = v[0]
+		config[k] = strings.Join(v, MULTIVALUE_ATTRIBUTE_SEPARATOR)
 	}
 
 	data.Set("config", config)


### PR DESCRIPTION
#548 

Implemented & documented the same multivalue behavior for `keycloak_custom_user_federation` resource as it's done in `keycloak_user`. 

