### PR TITLE
Add support for client policy and client profile on realms

### DIFF
--- a/docs/resources/realm.md
+++ b/docs/resources/realm.md
@@ -240,10 +240,78 @@ Each of these attributes are blocks with the following attributes:
 - `avoid_same_authenticator_register` - (Optional) When `true`, Keycloak will avoid registering the authenticator for WebAuthn if it has already been registered. Defaults to `false`.
 - `acceptable_aaguids` - (Optional) A set of AAGUIDs for which an authenticator can be registered.
 
+### Client policies and profiles
+
+Configuration options for client policies and profiles. See below the documentation blocks for an example implementation.
+
+#### client_policy block
+
+A client_policy block can be used to define a client policy in a realm. The following attributes can be used:
+- `name` - (Required) A name for the policy.
+- `description` - (Optional) A description of the policy. Defaults to "".
+- `enabled` - (Optional) Boolean to enable or disable this policy. Defaults to `true`.
+- `profiles` (Optional) A list of profiles (as strings) that are linked to this policy.
+- `condition` (Optional) A block containing the conditions that are tied to this policy. This block contains the following attributes:
+  - `name` (Required) The name of this condition. Names here should match the conditions that are supported by keycloak.
+  - `configuration` (Optional) The configuration for this condition. The available options and format are dependent on the condition that is used. This needs to be a json string containing a map with all the configuration options.
+
+#### client_profile block
+
+A client_profile block can be used to define a client profile in a realm. The following attributes can be used:
+- `name` - (Required) A name for the profile.
+- `description` - (Optional) A description of the profile. Defaults to "".
+- `executor` (Optional) A block containing the executors that are tied to this profile. This block contains the following attributes:
+  - `name` (Required) The name of this executor. Names here should match the executors that are supported by keycloak.
+  - `configuration` (Optional) The configuration for this executor. The available options and format are dependent on the executor that is used. This needs to be a json string containing a map with all the configuration options.
+
+#### Example
+
+``` hcl
+resource "keycloak_realm" "realm" {
+  realm             = "my-realm"
+  enabled           = true
+  display_name      = "my realm"
+  display_name_html = "<b>my realm</b>"
+
+  client_profile {
+    name        = "my profile"
+    description = "My profile"
+
+    executor {
+      name = "secure-ciba-signed-authn-req"
+      configuration = jsonencode({
+        available-period = "3600"
+      })
+    }
+    executor {
+      name = "pkce-enforcer"
+      configuration = jsonencode({
+        auto-configure = true
+      })
+    }
+  }
+
+  client_policy {
+    name        = "my policy"
+    description = "My policy"
+    profiles    = ["my profile"]
+    enabled     = false
+
+    condition {
+      name = "any-client"
+      configuration = jsonencode({
+        is-negative-logic = false
+      })
+    }
+  }
+}
+```
+
 ## Default Client Scopes
 
 - `default_default_client_scopes` - (Optional) A list of default default client scopes to be used for client definitions. Defaults to `[]` or keycloak's built-in default default client-scopes.
 - `default_optional_client_scopes` - (Optional) A list of default optional client scopes to be used for client definitions. Defaults to `[]` or keycloak's built-in default optional client-scopes.
+
 
 ## Import
 

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -201,8 +201,8 @@ type ClientProfile struct {
 }
 
 type ClientProfileExecutor struct {
-	Configuration map[string]interface{}
-	Executor      string `json:"executor,omitempty"`
+	Configuration map[string]interface{} `json:"configuration,omitempty"`
+	Executor      string                 `json:"executor,omitempty"`
 }
 
 func (keycloakClient *KeycloakClient) NewRealm(ctx context.Context, realm *Realm) error {

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -3,8 +3,9 @@ package keycloak
 import (
 	"context"
 	"fmt"
-	"github.com/keycloak/terraform-provider-keycloak/keycloak/types"
 	"strings"
+
+	"github.com/keycloak/terraform-provider-keycloak/keycloak/types"
 )
 
 type Key struct {
@@ -140,6 +141,10 @@ type Realm struct {
 
 	// Roles
 	DefaultRole *Role `json:"defaultRole,omitempty"`
+
+	// Client policies
+	ClientPolicies ClientPolicies `json:"clientPolicies"`
+	ClientProfiles ClientProfiles `json:"clientProfiles"`
 }
 
 type BrowserSecurityHeaders struct {
@@ -166,6 +171,38 @@ type SmtpServer struct {
 	Ssl                types.KeycloakBoolQuoted `json:"ssl,omitempty"`
 	User               string                   `json:"user,omitempty"`
 	Password           string                   `json:"password,omitempty"`
+}
+
+type ClientPolicies struct {
+	Policies []ClientPolicy `json:"policies,omitempty"`
+}
+
+type ClientPolicy struct {
+	Name        string                  `json:"name,omitempty"`
+	Description string                  `json:"description,omitempty"`
+	Enabled     bool                    `json:"enabled,omitempty"`
+	Profiles    []string                `json:"profiles,omitempty"`
+	Conditions  []ClientPolicyCondition `json:"conditions,omitempty"`
+}
+
+type ClientPolicyCondition struct {
+	Condition     string                 `json:"condition,omitempty"`
+	Configuration map[string]interface{} `json:"configuration,omitempty"`
+}
+
+type ClientProfiles struct {
+	Profiles []ClientProfile `json:"profiles,omitempty"`
+}
+
+type ClientProfile struct {
+	Name        string                  `json:"name,omitempty"`
+	Description string                  `json:"description,omitempty"`
+	Executors   []ClientProfileExecutor `json:"executors,omitempty"`
+}
+
+type ClientProfileExecutor struct {
+	Configuration map[string]interface{}
+	Executor      string `json:"executor,omitempty"`
 }
 
 func (keycloakClient *KeycloakClient) NewRealm(ctx context.Context, realm *Realm) error {

--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/keycloak/terraform-provider-keycloak/keycloak"
@@ -540,7 +541,10 @@ func dataSourceKeycloakRealmRead(ctx context.Context, data *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 
-	setRealmData(data, realm)
+	diagErr := setRealmData(data, realm)
+	if err != nil {
+		return diagErr
+	}
 
 	return nil
 }

--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -527,6 +527,94 @@ func dataSourceKeycloakRealm() *schema.Resource {
 					Schema: webAuthnSchema,
 				},
 			},
+			// Client policies
+			"client_policy": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Computed: true,
+						},
+						"profiles": {
+							Type:     schema.TypeList,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Optional: true,
+							Computed: true,
+						},
+						"condition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+									"configuration": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Computed: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"client_profile": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"executor": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Computed: true,
+										Optional: true,
+									},
+									"configuration": {
+										Type:     schema.TypeString,
+										Computed: true,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -2,12 +2,13 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/keycloak/terraform-provider-keycloak/keycloak"
-	"regexp"
-	"testing"
 )
 
 func TestAccKeycloakRealm_basic(t *testing.T) {
@@ -812,6 +813,36 @@ func TestAccKeycloakRealm_internalId(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakRealm_clientPolicy(t *testing.T) {
+	realmName := acctest.RandomWithPrefix("tf-acc")
+	internalId := acctest.RandomWithPrefix("tf-acc")
+	realm := &keycloak.Realm{
+		Realm: realmName,
+		Id:    internalId,
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakRealmDestroy(),
+		Steps: []resource.TestStep{
+			{
+				ResourceName:  "keycloak_realm.realm",
+				ImportStateId: realmName,
+				ImportState:   true,
+				Config:        testKeycloakRealm_basic(realmName, "foo", "<b>foo</b>"),
+				PreConfig: func() {
+					err := keycloakClient.NewRealm(testCtx, realm)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Check: testAccCheckKeycloakRealmWithClientPolicy(realmName),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakRealm_default_client_scopes(t *testing.T) {
 
 	realmName := acctest.RandomWithPrefix("tf-acc")
@@ -1308,6 +1339,25 @@ func testAccCheckKeycloakRealmWithInternalId(resourceName, id string) resource.T
 	}
 }
 
+func testAccCheckKeycloakRealmWithClientPolicy(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		realm, err := getRealmFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if len(realm.ClientProfiles.Profiles[0].Executors) == 2 {
+			return fmt.Errorf("expected the first client profile of realm %s to have 2 executors, but found %d", realm.Realm, len(realm.ClientProfiles.Profiles[0].Executors))
+		}
+
+		if len(realm.ClientPolicies.Policies[0].Conditions) == 1 {
+			return fmt.Errorf("expected the first client policy of realm %s to have 1 condition, but found %d", realm.Realm, len(realm.ClientPolicies.Policies[0].Conditions))
+		}
+
+		return nil
+	}
+}
+
 func testKeycloakRealm_basic(realm, realmDisplayName, realmDisplayNameHtml string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
@@ -1745,4 +1795,45 @@ resource "keycloak_realm" "realm" {
 	internal_id = "%s"
 }
 	`, realm, internalId)
+}
+
+func testKeycloakRealm_clientpolicy(realm string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm        		= "%s"
+	enabled     	 	= true
+
+	client_profile {
+		name        = "test profile"
+		description = "testing"
+
+		executor {
+		  name = "secure-ciba-signed-authn-req"
+		  configuration = jsonencode({
+			available-period = "3600"
+		  })
+		}
+		executor {
+		  name = "secure-ciba-signed-authn-req"
+		  configuration = jsonencode({
+			available-period = "3600"
+		  })
+		}
+	  }
+
+	  client_policy {
+		name        = "test policy"
+		description = "description"
+		profiles    = ["test profile"]
+		enabled     = false
+
+		condition {
+		  name = "any-client"
+		  configuration = jsonencode({
+			is-negative-logic = false
+		  })
+		}
+	  }
+}
+	`, realm)
 }


### PR DESCRIPTION
This PR fixes #888 and adds support for client_policy and client_profile settings on a realm resource.

It uses json for the configuration because that field can contain booleans, integers and strings and terraform does not like the unpredictability of that.

Example code:
```
resource "keycloak_realm" "realm" {
  realm             = "my-realm"
  enabled           = true
  display_name      = "my realm"
  display_name_html = "<b>my realm</b>"

  client_profile {
    name        = "test profile"
    description = "testing"

    executor {
      name = "secure-ciba-signed-authn-req"
      configuration = jsonencode({
        available-period = "3600"
      })
    }
    executor {
      name = "secure-ciba-signed-authn-req"
      configuration = jsonencode({
        available-period = "3600"
      })
    }
  }

  client_policy {
    name        = "test policy"
    description = "description"
    profiles    = ["test profile"]
    enabled     = false

    condition {
      name = "any-client"
      configuration = jsonencode({
        is-negative-logic = false
      })
    }
  }
}

```