### PR TITLE
Adds support for the ExcludeIssuerFromAuthResponse option on OpenIdClient

### DIFF
--- a/docs/resources/openid_client.md
+++ b/docs/resources/openid_client.md
@@ -87,6 +87,7 @@ is set to `true`.
   - `direct_grant_id` - (Optional) Direct grant flow id (flow needs to exist)
 - `login_theme` - (Optional) The client login theme. This will override the default theme for the realm.
 - `exclude_session_state_from_auth_response` - (Optional) When `true`, the parameter `session_state` will not be included in OpenID Connect Authentication Response.
+- `exclude_issuer_from_auth_response` - (Optional) When `true`, the parameter `iss` will not be included in OpenID Connect Authentication Response.
 - `use_refresh_tokens` - (Optional) If this is `true`, a refresh_token will be created and added to the token response. If this is `false` then no refresh_token will be generated.  Defaults to `true`.
 - `use_refresh_tokens_client_credentials` - (Optional) If this is `true`, a refresh_token will be created and added to the token response if the client_credentials grant is used and a user session will be created. If this is `false` then no refresh_token will be generated and the associated user session will be removed, in accordance with OAuth 2.0 RFC6749 Section 4.4.3. Defaults to `false`.
 - `oauth2_device_authorization_grant_enabled` - (Optional) Enables support for OAuth 2.0 Device Authorization Grant, which means that client is an application on device that has limited input capabilities or lack a suitable browser.

--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -61,6 +61,7 @@ type OpenidClient struct {
 type OpenidClientAttributes struct {
 	PkceCodeChallengeMethod               string                           `json:"pkce.code.challenge.method"`
 	ExcludeSessionStateFromAuthResponse   types.KeycloakBoolQuoted         `json:"exclude.session.state.from.auth.response"`
+	ExcludeIssuerFromAuthResponse         types.KeycloakBoolQuoted         `json:"exclude.issuer.from.auth.response"`
 	AccessTokenLifespan                   string                           `json:"access.token.lifespan"`
 	LoginTheme                            string                           `json:"login_theme"`
 	ClientOfflineSessionIdleTimeout       string                           `json:"client.offline.session.idle.timeout,omitempty"`

--- a/provider/data_source_keycloak_openid_client.go
+++ b/provider/data_source_keycloak_openid_client.go
@@ -128,6 +128,10 @@ func dataSourceKeycloakOpenidClient() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"exclude_issuer_from_auth_response": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"resource_server_id": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -175,6 +175,11 @@ func resourceKeycloakOpenidClient() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"exclude_issuer_from_auth_response": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"resource_server_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -356,6 +361,7 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 		Attributes: keycloak.OpenidClientAttributes{
 			PkceCodeChallengeMethod:               data.Get("pkce_code_challenge_method").(string),
 			ExcludeSessionStateFromAuthResponse:   types.KeycloakBoolQuoted(data.Get("exclude_session_state_from_auth_response").(bool)),
+			ExcludeIssuerFromAuthResponse:         types.KeycloakBoolQuoted(data.Get("exclude_issuer_from_auth_response").(bool)),
 			AccessTokenLifespan:                   data.Get("access_token_lifespan").(string),
 			LoginTheme:                            data.Get("login_theme").(string),
 			ClientOfflineSessionIdleTimeout:       data.Get("client_offline_session_idle_timeout").(string),

--- a/provider/resource_keycloak_openid_client_test.go
+++ b/provider/resource_keycloak_openid_client_test.go
@@ -31,7 +31,7 @@ func TestAccKeycloakOpenidClient_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     testAccRealm.Realm + "/",
-				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response"},
+				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response", "exclude_issuer_from_auth_response"},
 			},
 		},
 	})
@@ -55,7 +55,7 @@ func TestAccKeycloakOpenidClient_basic_with_consent(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     testAccRealm.Realm + "/",
-				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response"},
+				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response", "exclude_issuer_from_auth_response"},
 			},
 		},
 	})
@@ -331,7 +331,7 @@ func TestAccKeycloakOpenidClient_AccessToken_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     testAccRealm.Realm + "/",
-				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response"},
+				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response", "exclude_issuer_from_auth_response"},
 			},
 		},
 	})
@@ -363,7 +363,7 @@ func TestAccKeycloakOpenidClient_ClientTimeouts_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     testAccRealm.Realm + "/",
-				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response"},
+				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response", "exclude_issuer_from_auth_response"},
 			},
 		},
 	})
@@ -399,7 +399,7 @@ func TestAccKeycloakOpenidClient_Device_basic(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdPrefix:     testAccRealm.Realm + "/",
-				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response"},
+				ImportStateVerifyIgnore: []string{"exclude_session_state_from_auth_response", "exclude_issuer_from_auth_response"},
 			},
 		},
 	})
@@ -519,6 +519,7 @@ func TestAccKeycloakOpenidClient_pkceCodeChallengeMethod(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeycloakOpenidClientHasPkceCodeChallengeMethod("keycloak_openid_client.client", ""),
 					testAccCheckKeycloakOpenidClientHasExcludeSessionStateFromAuthResponse("keycloak_openid_client.client", false),
+					testAccCheckKeycloakOpenidClientHasExcludeIssuerFromAuthResponse("keycloak_openid_client.client", false),
 				),
 			},
 			{
@@ -526,6 +527,7 @@ func TestAccKeycloakOpenidClient_pkceCodeChallengeMethod(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeycloakOpenidClientHasPkceCodeChallengeMethod("keycloak_openid_client.client", "plain"),
 					testAccCheckKeycloakOpenidClientHasExcludeSessionStateFromAuthResponse("keycloak_openid_client.client", false),
+					testAccCheckKeycloakOpenidClientHasExcludeIssuerFromAuthResponse("keycloak_openid_client.client", false),
 				),
 			},
 			{
@@ -533,6 +535,7 @@ func TestAccKeycloakOpenidClient_pkceCodeChallengeMethod(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeycloakOpenidClientHasPkceCodeChallengeMethod("keycloak_openid_client.client", "S256"),
 					testAccCheckKeycloakOpenidClientHasExcludeSessionStateFromAuthResponse("keycloak_openid_client.client", false),
+					testAccCheckKeycloakOpenidClientHasExcludeIssuerFromAuthResponse("keycloak_openid_client.client", false),
 				),
 			},
 			{
@@ -540,6 +543,7 @@ func TestAccKeycloakOpenidClient_pkceCodeChallengeMethod(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeycloakOpenidClientHasPkceCodeChallengeMethod("keycloak_openid_client.client", ""),
 					testAccCheckKeycloakOpenidClientHasExcludeSessionStateFromAuthResponse("keycloak_openid_client.client", false),
+					testAccCheckKeycloakOpenidClientHasExcludeIssuerFromAuthResponse("keycloak_openid_client.client", false),
 				),
 			},
 		},
@@ -580,6 +584,47 @@ func TestAccKeycloakOpenidClient_excludeSessionStateFromAuthResponse(t *testing.
 				Config: testKeycloakOpenidClient_excludeSessionStateFromAuthResponse(clientId, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeycloakOpenidClientHasExcludeSessionStateFromAuthResponse("keycloak_openid_client.client", false),
+					testAccCheckKeycloakOpenidClientHasPkceCodeChallengeMethod("keycloak_openid_client.client", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOpenidClient_excludeIssuerFromAuthResponse(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOpenidClientDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenidClient_omitExcludeIssuerFromAuthResponse(clientId, "plain"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidClientHasExcludeIssuerFromAuthResponse("keycloak_openid_client.client", false),
+					testAccCheckKeycloakOpenidClientHasPkceCodeChallengeMethod("keycloak_openid_client.client", "plain"),
+				),
+			},
+			{
+				Config: testKeycloakOpenidClient_excludeIssuerFromAuthResponse(clientId, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidClientHasExcludeIssuerFromAuthResponse("keycloak_openid_client.client", false),
+					testAccCheckKeycloakOpenidClientHasPkceCodeChallengeMethod("keycloak_openid_client.client", ""),
+				),
+			},
+			{
+				Config: testKeycloakOpenidClient_excludeIssuerFromAuthResponse(clientId, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidClientHasExcludeIssuerFromAuthResponse("keycloak_openid_client.client", true),
+					testAccCheckKeycloakOpenidClientHasPkceCodeChallengeMethod("keycloak_openid_client.client", ""),
+				),
+			},
+			{
+				Config: testKeycloakOpenidClient_excludeIssuerFromAuthResponse(clientId, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidClientHasExcludeIssuerFromAuthResponse("keycloak_openid_client.client", false),
 					testAccCheckKeycloakOpenidClientHasPkceCodeChallengeMethod("keycloak_openid_client.client", ""),
 				),
 			},
@@ -1086,6 +1131,21 @@ func testAccCheckKeycloakOpenidClientHasExcludeSessionStateFromAuthResponse(reso
 	}
 }
 
+func testAccCheckKeycloakOpenidClientHasExcludeIssuerFromAuthResponse(resourceName string, excludeIssuerFromAuthResponse types.KeycloakBoolQuoted) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := getOpenidClientFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if client.Attributes.ExcludeIssuerFromAuthResponse != excludeIssuerFromAuthResponse {
+			return fmt.Errorf("expected openid client %s to have exclude_issuer_from_auth_response value of %t, but got %t", client.ClientId, excludeIssuerFromAuthResponse, client.Attributes.ExcludeIssuerFromAuthResponse)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckKeycloakOpenidClientAuthenticationFlowBindingOverrides(resourceName, flowResourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client, err := getOpenidClientFromState(s, resourceName)
@@ -1381,6 +1441,22 @@ resource "keycloak_openid_client" "client" {
 	`, testAccRealm.Realm, clientId, excludeSessionStateFromAuthResponse)
 }
 
+func testKeycloakOpenidClient_excludeIssuerFromAuthResponse(clientId string, excludeIssuerFromAuthResponse bool) string {
+
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "client" {
+	client_id   = "%s"
+	realm_id    = data.keycloak_realm.realm.id
+	access_type = "CONFIDENTIAL"
+	exclude_issuer_from_auth_response = %t
+}
+	`, testAccRealm.Realm, clientId, excludeIssuerFromAuthResponse)
+}
+
 func testKeycloakOpenidClient_omitPkceChallengeMethod(clientId string) string {
 
 	return fmt.Sprintf(`
@@ -1397,6 +1473,22 @@ resource "keycloak_openid_client" "client" {
 }
 
 func testKeycloakOpenidClient_omitExcludeSessionStateFromAuthResponse(clientId, pkceChallengeMethod string) string {
+
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "client" {
+	client_id   = "%s"
+	realm_id    = data.keycloak_realm.realm.id
+	access_type = "CONFIDENTIAL"
+    pkce_code_challenge_method = "%s"
+}
+	`, testAccRealm.Realm, clientId, pkceChallengeMethod)
+}
+
+func testKeycloakOpenidClient_omitExcludeIssuerFromAuthResponse(clientId, pkceChallengeMethod string) string {
 
 	return fmt.Sprintf(`
 data "keycloak_realm" "realm" {


### PR DESCRIPTION
Solves https://github.com/mrparkers/terraform-provider-keycloak/issues/928

What has been changed :
- new `ExcludeIssuerFromAuthResponse` attribute in the client
- the resource schema is updated with `ExcludeIssuerFromAuthResponse` attribute
- the datasource `openid_client` also returns this attribute
- tests were updated + one new test case to check that the option is well updated
- provider documentation returns the new attribute with the same words Keycloak uses