### PR TITLE
refactor: speed up audience mapper validation

### DIFF
--- a/keycloak/openid_audience_protocol_mapper.go
+++ b/keycloak/openid_audience_protocol_mapper.go
@@ -124,18 +124,10 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdAudienceProtocolMapper(ctx c
 	}
 
 	if mapper.IncludedClientAudience != "" {
-		clients, err := keycloakClient.listGenericClients(ctx, mapper.RealmId)
+		_, err = keycloakClient.GetGenericClientByClientId(ctx, mapper.RealmId, mapper.IncludedClientAudience)
 		if err != nil {
-			return err
+			return fmt.Errorf("validation error: %w", err)
 		}
-
-		for _, client := range clients {
-			if client.ClientId == mapper.IncludedClientAudience {
-				return nil
-			}
-		}
-
-		return fmt.Errorf("validation error: client %s does not exist", mapper.IncludedClientAudience)
 	}
 
 	return nil

--- a/provider/resource_keycloak_openid_audience_protocol_mapper_test.go
+++ b/provider/resource_keycloak_openid_audience_protocol_mapper_test.go
@@ -233,7 +233,7 @@ func TestAccKeycloakOpenIdAudienceProtocolMapper_validateClientAudienceExists(t 
 		Steps: []resource.TestStep{
 			{
 				Config:      testKeycloakOpenIdAudienceProtocolMapper_validateClientAudienceExists(clientId, mapperName),
-				ExpectError: regexp.MustCompile("validation error: client .+ does not exist"),
+				ExpectError: regexp.MustCompile("validation error: generic client with name \\S+ does not exist"),
 			},
 		},
 	})


### PR DESCRIPTION
Do not load all clients when validating client audience for audience mappers. Instead, try to fetch the client in question directly.

Closes #960 