### PR TITLE
Add priority field support in authentication flow executions

### DIFF
--- a/docs/resources/authentication_execution.md
+++ b/docs/resources/authentication_execution.md
@@ -9,7 +9,7 @@ Allows for creating and managing an authentication execution within Keycloak.
 An authentication execution is an action that the user or service may or may not take when authenticating through an authentication
 flow.
 
-~> Due to limitations in the Keycloak API, the ordering of authentication executions within a flow must be specified using `depends_on`. Authentication executions that are created first will appear first within the flow.
+~> Due to limitations in the Keycloak API, the ordering of authentication executions within a flow must be specified using `depends_on` in versions prior to Keycloak 25. Authentication executions that are created first will appear first within the flow.
 
 ## Example Usage
 
@@ -30,6 +30,7 @@ resource "keycloak_authentication_execution" "execution_one" {
   parent_flow_alias = "${keycloak_authentication_flow.flow.alias}"
   authenticator     = "auth-cookie"
   requirement       = "ALTERNATIVE"
+  priority          = 10 # Starting from Keycloak 25
 }
 
 # second execution
@@ -38,7 +39,9 @@ resource "keycloak_authentication_execution" "execution_two" {
   parent_flow_alias = "${keycloak_authentication_flow.flow.alias}"
   authenticator     = "identity-provider-redirector"
   requirement       = "ALTERNATIVE"
+  priority          = 20 # Starting from Keycloak 25
 
+  # Workaround for older Keycloak versions (Keycloak 24 and older)
   depends_on = [
     keycloak_authentication_execution.execution_one
   ]
@@ -51,6 +54,7 @@ resource "keycloak_authentication_execution" "execution_two" {
 - `parent_flow_alias` - (Required) The alias of the flow this execution is attached to.
 - `authenticator` - (Required) The name of the authenticator. This can be found by experimenting with the GUI and looking at HTTP requests within the network tab of your browser's development tools.
 - `requirement`- (Optional) The requirement setting, which can be one of `REQUIRED`, `ALTERNATIVE`, `OPTIONAL`, `CONDITIONAL`, or `DISABLED`. Defaults to `DISABLED`.
+- `priority`- (Optional) The authenticator priority, the lower the value the higher it will be placed in the parent flow. This option is supported only by Keycloak 25 and onwards.
 
 ## Import
 

--- a/docs/resources/authentication_subflow.md
+++ b/docs/resources/authentication_subflow.md
@@ -28,6 +28,7 @@ resource "keycloak_authentication_subflow" "subflow" {
   parent_flow_alias = keycloak_authentication_flow.flow.alias
   provider_id       = "basic-flow"
   requirement       = "ALTERNATIVE"
+  priority          = 10 # Starting from Keycloak 25
 }
 ```
 
@@ -43,6 +44,7 @@ and `client-flow`. Defaults to `basic-flow`.
 authenticators. In general this will remain empty.
 - `requirement`- (Optional) The requirement setting, which can be one of `REQUIRED`, `ALTERNATIVE`, `OPTIONAL`, `CONDITIONAL`,
 or `DISABLED`. Defaults to `DISABLED`.
+- `priority`- (Optional) The subflow priority, the lower the value the higher it will be placed in the parent flow. This option is supported only by Keycloak 25 and onwards.
 
 ## Import
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -1020,9 +1020,7 @@ resource "keycloak_authentication_execution" "browser-copy-cookie" {
   parent_flow_alias = keycloak_authentication_flow.browser-copy-flow.alias
   authenticator     = "auth-cookie"
   requirement       = "ALTERNATIVE"
-  depends_on = [
-    keycloak_authentication_execution.browser-copy-kerberos
-  ]
+  priority          = 20
 }
 
 resource "keycloak_authentication_execution" "browser-copy-kerberos" {
@@ -1030,6 +1028,7 @@ resource "keycloak_authentication_execution" "browser-copy-kerberos" {
   parent_flow_alias = keycloak_authentication_flow.browser-copy-flow.alias
   authenticator     = "auth-spnego"
   requirement       = "DISABLED"
+  priority          = 10
 }
 
 resource "keycloak_authentication_execution" "browser-copy-idp-redirect" {
@@ -1037,9 +1036,7 @@ resource "keycloak_authentication_execution" "browser-copy-idp-redirect" {
   parent_flow_alias = keycloak_authentication_flow.browser-copy-flow.alias
   authenticator     = "identity-provider-redirector"
   requirement       = "ALTERNATIVE"
-  depends_on = [
-    keycloak_authentication_execution.browser-copy-cookie
-  ]
+  priority          = 30
 }
 
 resource "keycloak_authentication_subflow" "browser-copy-flow-forms" {
@@ -1047,9 +1044,7 @@ resource "keycloak_authentication_subflow" "browser-copy-flow-forms" {
   parent_flow_alias = keycloak_authentication_flow.browser-copy-flow.alias
   alias             = "browser-copy-flow-forms"
   requirement       = "ALTERNATIVE"
-  depends_on = [
-    keycloak_authentication_execution.browser-copy-idp-redirect
-  ]
+  priority          = 40
 }
 
 resource "keycloak_authentication_execution" "browser-copy-auth-username-password-form" {
@@ -1057,6 +1052,7 @@ resource "keycloak_authentication_execution" "browser-copy-auth-username-passwor
   parent_flow_alias = keycloak_authentication_subflow.browser-copy-flow-forms.alias
   authenticator     = "auth-username-password-form"
   requirement       = "REQUIRED"
+  priority          = 10
 }
 
 resource "keycloak_authentication_execution" "browser-copy-otp" {
@@ -1064,9 +1060,7 @@ resource "keycloak_authentication_execution" "browser-copy-otp" {
   parent_flow_alias = keycloak_authentication_subflow.browser-copy-flow-forms.alias
   authenticator     = "auth-otp-form"
   requirement       = "REQUIRED"
-  depends_on = [
-    keycloak_authentication_execution.browser-copy-auth-username-password-form
-  ]
+  priority          = 20
 }
 
 resource "keycloak_authentication_execution_config" "config" {

--- a/keycloak/authentication_subflow.go
+++ b/keycloak/authentication_subflow.go
@@ -71,6 +71,9 @@ func (keycloakClient *KeycloakClient) GetAuthenticationSubFlow(ctx context.Conte
 	}
 	authenticationSubFlow.Authenticator = subFlowExecution.Authenticator
 	authenticationSubFlow.Requirement = subFlowExecution.Requirement
+	if prioritySupported, _ := keycloakClient.VersionIsGreaterThanOrEqualTo(ctx, Version_25); prioritySupported {
+		authenticationSubFlow.Priority = subFlowExecution.Priority
+	}
 
 	return &authenticationSubFlow, nil
 }
@@ -111,6 +114,9 @@ func (keycloakClient *KeycloakClient) UpdateAuthenticationSubFlow(ctx context.Co
 		Id:              executionId,
 		Requirement:     authenticationSubFlow.Requirement,
 	}
+	if prioritySupported, _ := keycloakClient.VersionIsGreaterThanOrEqualTo(ctx, Version_25); prioritySupported {
+		authenticationExecutionUpdateRequirement.Priority = authenticationSubFlow.Priority
+	}
 	return keycloakClient.UpdateAuthenticationExecutionRequirement(ctx, authenticationExecutionUpdateRequirement)
 
 }
@@ -127,32 +133,4 @@ func (keycloakClient *KeycloakClient) DeleteAuthenticationSubFlow(ctx context.Co
 	}
 
 	return keycloakClient.DeleteAuthenticationExecution(ctx, authenticationSubFlow.RealmId, executionId)
-}
-
-func (keycloakClient *KeycloakClient) RaiseAuthenticationSubFlowPriority(ctx context.Context, realmId, parentFlowAlias, id string) error {
-	authenticationSubFlow := AuthenticationSubFlow{
-		Id:              id,
-		ParentFlowAlias: parentFlowAlias,
-		RealmId:         realmId,
-	}
-	executionId, err := keycloakClient.getExecutionId(ctx, &authenticationSubFlow)
-	if err != nil {
-		return err
-	}
-
-	return keycloakClient.RaiseAuthenticationExecutionPriority(ctx, authenticationSubFlow.RealmId, executionId)
-}
-
-func (keycloakClient *KeycloakClient) LowerAuthenticationSubFlowPriority(ctx context.Context, realmId, parentFlowAlias, id string) error {
-	authenticationSubFlow := AuthenticationSubFlow{
-		Id:              id,
-		ParentFlowAlias: parentFlowAlias,
-		RealmId:         realmId,
-	}
-	executionId, err := keycloakClient.getExecutionId(ctx, &authenticationSubFlow)
-	if err != nil {
-		return err
-	}
-
-	return keycloakClient.LowerAuthenticationExecutionPriority(ctx, authenticationSubFlow.RealmId, executionId)
 }

--- a/keycloak/version.go
+++ b/keycloak/version.go
@@ -74,3 +74,19 @@ func (keycloakClient *KeycloakClient) VersionIsLessThanOrEqualTo(ctx context.Con
 
 	return keycloakClient.version.LessThanOrEqual(v), nil
 }
+
+func (keycloakClient *KeycloakClient) VersionIsLessThan(ctx context.Context, versionString Version) (bool, error) {
+	if keycloakClient.version == nil {
+		err := keycloakClient.login(ctx)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	v, err := version.NewVersion(string(versionString))
+	if err != nil {
+		return false, nil
+	}
+
+	return keycloakClient.version.LessThan(v), nil
+}

--- a/provider/data_source_keycloak_authentication_execution.go
+++ b/provider/data_source_keycloak_authentication_execution.go
@@ -23,6 +23,10 @@ func dataSourceKeycloakAuthenticationExecution() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"priority": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -39,7 +43,7 @@ func dataSourceKeycloakAuthenticationExecutionRead(ctx context.Context, data *sc
 		return diag.FromErr(err)
 	}
 
-	mapFromAuthenticationExecutionInfoToData(data, authenticationExecutionInfo)
+	mapFromAuthenticationExecutionInfoToData(keycloakClient, ctx, data, authenticationExecutionInfo)
 
 	return nil
 }

--- a/provider/resource_keycloak_authentication_execution_config_test.go
+++ b/provider/resource_keycloak_authentication_execution_config_test.go
@@ -199,6 +199,7 @@ resource "keycloak_authentication_execution" "execution" {
 	realm_id          = data.keycloak_realm.realm.id
 	parent_flow_alias = keycloak_authentication_flow.flow.alias
 	authenticator     = "identity-provider-redirector"
+	priority          = 10
 }
 
 resource "keycloak_authentication_execution_config" "config" {

--- a/provider/test_utils.go
+++ b/provider/test_utils.go
@@ -79,6 +79,17 @@ func skipIfVersionIsLessThanOrEqualTo(ctx context.Context, t *testing.T, keycloa
 	}
 }
 
+func skipIfVersionIsLessThan(ctx context.Context, t *testing.T, keycloakClient *keycloak.KeycloakClient, version keycloak.Version) {
+	ok, err := keycloakClient.VersionIsLessThan(ctx, version)
+	if err != nil {
+		t.Errorf("error checking keycloak version: %v", err)
+	}
+
+	if ok {
+		t.Skipf("keycloak server version is less than %s, skipping...", version)
+	}
+}
+
 func skipIfVersionIsGreaterThanOrEqualTo(ctx context.Context, t *testing.T, keycloakClient *keycloak.KeycloakClient, version keycloak.Version) {
 	ok, err := keycloakClient.VersionIsGreaterThanOrEqualTo(ctx, version)
 	if err != nil {


### PR DESCRIPTION
Allows to declaratively define authentication flow execution and subflow priority in Keycloak 25 onwards.

Additionally I've removed raisePriority/lowerPriority functions as they don't seem to be used anywhere.

Fixes #296