### PR TITLE
feat: add fine-grained realm-wide client scope management

### DIFF
--- a/docs/resources/openid_default_client_scope.md
+++ b/docs/resources/openid_default_client_scope.md
@@ -1,0 +1,37 @@
+---
+page_title: "keycloak_openid_default_client_scope Resource"
+---
+
+# keycloak\_openid\_default\_client\_scope Resource
+
+Manages a **realm-wide default client scope** in Keycloak. When a default client scope is assigned at the realm level, it is automatically applied to all new clients in the realm that use the OpenID Connect protocol. The protocol mappers defined within the scope are included by default in the claims for all clients, regardless of the provided OAuth2.0 `scope` parameter.
+
+!> Using `keycloak_openid_default_client_scope` will conflict with `keycloak_realm.default_default_client_scopes`.
+
+Unlike the list-based resource (`keycloak_openid_client_default_scopes`), this resource is **not** authoritative for realm-wide default client scopes. Instead, it allows you to add or manage a single client scope without modifying other default client scopes already present in the realm.
+
+!> This resource should be created before any clients that will use the default client scope.
+
+## Example Usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+resource "keycloak_openid_client_scope" "openid_client_scope" {
+  realm_id = keycloak_realm.realm.id
+  name     = "groups"
+}
+
+resource "keycloak_openid_default_client_scope" "openid_default_client_scope" {
+  realm_id        = keycloak_realm.realm.id
+  client_scope_id = keycloak_openid_client_scope.client_scope.id
+}
+```
+
+## Argument Reference
+
+- `realm_id` - (Required) The realm this client scope belongs to.
+- `client_scope_id` - (Required) The client scope to manage.

--- a/docs/resources/openid_optional_client_scope.md
+++ b/docs/resources/openid_optional_client_scope.md
@@ -1,0 +1,37 @@
+---
+page_title: "keycloak_openid_optional_client_scope Resource"
+---
+
+# keycloak\_openid\_optional\_client\_scope Resource
+
+Manages a **realm-wide optional client scope** in Keycloak. When an optional client scope is assigned at the realm level, it automatically applies to all new clients in the realm that use the OpenID Connect protocol. The protocol mappers defined within the scope become available to build claims for any client that requests them by including the OAuth2.0 `scope` parameter.
+
+!> Using `keycloak_openid_optional_client_scope` will conflict with `keycloak_realm.default_optional_client_scopes`.
+
+Unlike the list-based resource (`keycloak_openid_client_optional_scopes`), this resource is **not** authoritative for realm-wide optional client scopes. Instead, it allows you to add or manage a single client scope without modifying other optional client scopes already present in the realm.
+
+!> This resource should be created before any clients that will use the default client scope.
+
+## Example Usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+resource "keycloak_openid_client_scope" "openid_client_scope" {
+  realm_id = keycloak_realm.realm.id
+  name     = "groups"
+}
+
+resource "keycloak_openid_optional_client_scope" "openid_optional_client_scope" {
+  realm_id        = keycloak_realm.realm.id
+  client_scope_id = keycloak_openid_client_scope.client_scope.id
+}
+```
+
+## Argument Reference
+
+- `realm_id` - (Required) The realm this client scope belongs to.
+- `client_scope_id` - (Required) The client scope to manage.

--- a/keycloak/openid_default_client_scope.go
+++ b/keycloak/openid_default_client_scope.go
@@ -1,0 +1,31 @@
+package keycloak
+
+import (
+	"context"
+	"fmt"
+)
+
+func (keycloakClient *KeycloakClient) GetOpenidRealmDefaultClientScope(ctx context.Context, realmId, clientScopeId string) (*OpenidClientScope, error) {
+	var clientScopes []OpenidClientScope
+
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/default-default-client-scopes", realmId), &clientScopes, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, clientScope := range clientScopes {
+		if clientScope.Id == clientScopeId {
+			return &clientScope, nil
+		}
+	}
+
+	return nil, err
+}
+
+func (keycloakClient *KeycloakClient) PutOpenidRealmDefaultClientScope(ctx context.Context, realmId, clientScopeId string) error {
+	return keycloakClient.put(ctx, fmt.Sprintf("/realms/%s/default-default-client-scopes/%s", realmId, clientScopeId), nil)
+}
+
+func (keycloakClient *KeycloakClient) DeleteOpenidRealmDefaultClientScope(ctx context.Context, realmId, clientScopeId string) error {
+	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/default-default-client-scopes/%s", realmId, clientScopeId), nil)
+}

--- a/keycloak/openid_optional_client_scope.go
+++ b/keycloak/openid_optional_client_scope.go
@@ -1,0 +1,31 @@
+package keycloak
+
+import (
+	"context"
+	"fmt"
+)
+
+func (keycloakClient *KeycloakClient) GetOpenidRealmOptionalClientScope(ctx context.Context, realmId, clientScopeId string) (*OpenidClientScope, error) {
+	var clientScopes []OpenidClientScope
+
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/default-optional-client-scopes", realmId), &clientScopes, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, clientScope := range clientScopes {
+		if clientScope.Id == clientScopeId {
+			return &clientScope, nil
+		}
+	}
+
+	return nil, err
+}
+
+func (keycloakClient *KeycloakClient) PutOpenidRealmOptionalClientScope(ctx context.Context, realmId, clientScopeId string) error {
+	return keycloakClient.put(ctx, fmt.Sprintf("/realms/%s/default-optional-client-scopes/%s", realmId, clientScopeId), nil)
+}
+
+func (keycloakClient *KeycloakClient) DeleteOpenidRealmOptionalClientScope(ctx context.Context, realmId, clientScopeId string) error {
+	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/default-optional-client-scopes/%s", realmId, clientScopeId), nil)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -49,6 +49,8 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 			"keycloak_user_roles":                                        resourceKeycloakUserRoles(),
 			"keycloak_openid_client":                                     resourceKeycloakOpenidClient(),
 			"keycloak_openid_client_scope":                               resourceKeycloakOpenidClientScope(),
+			"keycloak_openid_default_client_scope":                       resourceKeycloakOpenidDefaultClientScope(),
+			"keycloak_openid_optional_client_scope":                      resourceKeycloakOpenidOptionalClientScope(),
 			"keycloak_ldap_user_federation":                              resourceKeycloakLdapUserFederation(),
 			"keycloak_ldap_user_attribute_mapper":                        resourceKeycloakLdapUserAttributeMapper(),
 			"keycloak_ldap_group_mapper":                                 resourceKeycloakLdapGroupMapper(),

--- a/provider/resource_keycloak_openid_default_client_scope.go
+++ b/provider/resource_keycloak_openid_default_client_scope.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakOpenidDefaultClientScope() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKeycloakOpenidDefaultClientScopeCreate,
+		ReadContext:   resourceKeycloakOpenidDefaultClientScopesRead,
+		DeleteContext: resourceKeycloakOpenidDefaultClientScopeDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakOpenidDefaultClientScopeImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"client_scope_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func parseKeycloakOpenidDefaultClientScopeDataIdtoRealmIdClientScopeId(id string) (string, string, error) {
+	parts := strings.Split(id, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Invalid import. Supported import formats: {{realmId}}/{{openidClientScopeId}}")
+	}
+	return parts[0], parts[1], nil
+}
+
+func parseKeycloakOpenidDefaultClientScopeRealmIdClientScopeIdToDataId(realmId string, clientScopeId string) string {
+	return fmt.Sprintf("%s/%s", realmId, clientScopeId)
+}
+
+func resourceKeycloakOpenidDefaultClientScopeCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	clientScopeId := data.Get("client_scope_id").(string)
+
+	err := keycloakClient.PutOpenidRealmDefaultClientScope(ctx, realmId, clientScopeId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(parseKeycloakOpenidDefaultClientScopeRealmIdClientScopeIdToDataId(realmId, clientScopeId))
+	return nil
+}
+
+func resourceKeycloakOpenidDefaultClientScopesRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	clientScopeId := data.Get("client_scope_id").(string)
+
+	clientScope, err := keycloakClient.GetOpenidRealmDefaultClientScope(ctx, realmId, clientScopeId)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	data.SetId(parseKeycloakOpenidDefaultClientScopeRealmIdClientScopeIdToDataId(realmId, clientScopeId))
+	data.Set("realm_id", realmId)
+	data.Set("client_scope_id", clientScope.Id)
+
+	return nil
+}
+
+func resourceKeycloakOpenidDefaultClientScopeDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	clientScopeId := data.Get("client_scope_id").(string)
+
+	return diag.FromErr(keycloakClient.DeleteOpenidRealmDefaultClientScope(ctx, realmId, clientScopeId))
+}
+
+func resourceKeycloakOpenidDefaultClientScopeImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	realmId, clientScopeId, err := parseKeycloakOpenidDefaultClientScopeDataIdtoRealmIdClientScopeId(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("realm_id", realmId)
+	d.Set("client_scope_id", clientScopeId)
+	d.SetId(d.Id())
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/provider/resource_keycloak_openid_default_client_scope_test.go
+++ b/provider/resource_keycloak_openid_default_client_scope_test.go
@@ -1,0 +1,136 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccKeycloakOpenidDefaultClientScope_basic(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+	clientScopeId := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccKeycloakOpenidDefaultClientScopeConfigDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeycloakOpenidDefaultClientScopeConfig(clientId, clientScopeId),
+				Check:  testAccCheckKeycloakOpenidClientHasDefaultScope(),
+			},
+			{
+				ResourceName:      "keycloak_openid_default_client_scope.openid_default_client_scope",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getKeycloakOpenidDefaultClientScopeImportId("keycloak_openid_default_client_scope.openid_default_client_scope"),
+			},
+		},
+	})
+}
+
+func testAccKeycloakOpenidDefaultClientScopeConfigDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "keycloak_openid_default_client_scope" {
+				continue
+			}
+
+			id := rs.Primary.ID
+			realmId := rs.Primary.Attributes["realm_id"]
+			clientScopeId := rs.Primary.Attributes["client_scope_id"]
+
+			clientScope, _ := keycloakClient.GetOpenidRealmDefaultClientScope(testCtx, realmId, clientScopeId)
+			if clientScope != nil {
+				return fmt.Errorf("default client scope mapping with id %s still exists", id)
+			}
+		}
+
+		return nil
+	}
+}
+
+func getKeycloakOpenidDefaultClientScopeImportId(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource %s not found", resourceName)
+		}
+
+		id := rs.Primary.ID
+
+		return id, nil
+	}
+}
+
+func testAccCheckKeycloakOpenidClientHasDefaultScope() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		resourceName := "keycloak_openid_default_client_scope.openid_default_client_scope"
+		rsClientScope, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		resourceName = "keycloak_openid_client.openid_client"
+		rsClient, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		realm := rsClientScope.Primary.Attributes["realm_id"]
+		clientScopeId := rsClientScope.Primary.Attributes["client_scope_id"]
+
+		clientId := rsClient.Primary.ID
+
+		keycloakDefaultClientScopes, err := keycloakClient.GetOpenidClientDefaultScopes(testCtx, realm, clientId)
+
+		if err != nil {
+			return err
+		}
+
+		var found = false
+		for _, keycloakDefaultScope := range keycloakDefaultClientScopes {
+			if keycloakDefaultScope.Id == clientScopeId {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("default scope %s is not assigned to client", clientScopeId)
+		}
+
+		return nil
+	}
+}
+
+func testAccKeycloakOpenidDefaultClientScopeConfig(clientId string, clientScopeId string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client_scope" "openid_client_scope" {
+  realm_id = data.keycloak_realm.realm.id
+  name     = "%s"
+}
+
+resource "keycloak_openid_default_client_scope" "openid_default_client_scope" {
+	realm_id        = data.keycloak_realm.realm.id
+	client_scope_id = keycloak_openid_client_scope.openid_client_scope.id
+}
+
+resource "keycloak_openid_client" "openid_client" {
+	realm_id    = data.keycloak_realm.realm.id
+	client_id   = "%s"
+	access_type = "CONFIDENTIAL"
+	depends_on  = [keycloak_openid_default_client_scope.openid_default_client_scope]
+}
+`, testAccRealm.Realm, clientScopeId, clientId)
+}

--- a/provider/resource_keycloak_openid_optional_client_scope.go
+++ b/provider/resource_keycloak_openid_optional_client_scope.go
@@ -1,0 +1,102 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakOpenidOptionalClientScope() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKeycloakOpenidOptionalClientScopeCreate,
+		ReadContext:   resourceKeycloakOpenidOptionalClientScopesRead,
+		DeleteContext: resourceKeycloakOpenidOptionalClientScopeDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakOpenidOptionalClientScopeImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"client_scope_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func parseKeycloakOpenidOptionalClientScopeDataIdtoRealmIdClientId(id string) (string, string, error) {
+	parts := strings.Split(id, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("Invalid import. Supported import formats: {{realmId}}/{{openidClientScopeId}}")
+	}
+	return parts[0], parts[1], nil
+}
+
+func parseKeycloakOpenidOptionalClientScopeRealmIdClientIdToDataId(realmId string, clientScopeId string) string {
+	return fmt.Sprintf("%s/%s", realmId, clientScopeId)
+}
+
+func resourceKeycloakOpenidOptionalClientScopeCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	clientScopeId := data.Get("client_scope_id").(string)
+
+	err := keycloakClient.PutOpenidRealmOptionalClientScope(ctx, realmId, clientScopeId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(parseKeycloakOpenidOptionalClientScopeRealmIdClientIdToDataId(realmId, clientScopeId))
+	return nil
+}
+
+func resourceKeycloakOpenidOptionalClientScopesRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	clientScopeId := data.Get("client_scope_id").(string)
+
+	clientScope, err := keycloakClient.GetOpenidRealmOptionalClientScope(ctx, realmId, clientScopeId)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	data.SetId(parseKeycloakOpenidOptionalClientScopeRealmIdClientIdToDataId(realmId, clientScopeId))
+	data.Set("realm_id", realmId)
+	data.Set("client_scope_id", clientScope.Id)
+
+	return nil
+}
+
+func resourceKeycloakOpenidOptionalClientScopeDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	clientScopeId := data.Get("client_scope_id").(string)
+
+	return diag.FromErr(keycloakClient.DeleteOpenidRealmOptionalClientScope(ctx, realmId, clientScopeId))
+}
+
+func resourceKeycloakOpenidOptionalClientScopeImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	realmId, clientScopeId, err := parseKeycloakOpenidOptionalClientScopeDataIdtoRealmIdClientId(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("realm_id", realmId)
+	d.Set("client_scope_id", clientScopeId)
+	d.SetId(d.Id())
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/provider/resource_keycloak_openid_optional_client_scope_test.go
+++ b/provider/resource_keycloak_openid_optional_client_scope_test.go
@@ -1,0 +1,136 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccKeycloakOpenidOptionalClientScope_basic(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+	clientScopeId := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccKeycloakOpenidOptionalClientScopeConfigDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeycloakOpenidOptionalClientScopeConfig(clientId, clientScopeId),
+				Check:  testAccCheckKeycloakOpenidClientHasOptionalScope(),
+			},
+			{
+				ResourceName:      "keycloak_openid_optional_client_scope.openid_optional_client_scope",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getKeycloakOpenidOptionalClientScopeImportId("keycloak_openid_optional_client_scope.openid_optional_client_scope"),
+			},
+		},
+	})
+}
+
+func testAccKeycloakOpenidOptionalClientScopeConfigDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "keycloak_openid_optional_client_scope" {
+				continue
+			}
+
+			id := rs.Primary.ID
+			realmId := rs.Primary.Attributes["realm_id"]
+			clientScopeId := rs.Primary.Attributes["client_scope_id"]
+
+			clientScope, _ := keycloakClient.GetOpenidRealmOptionalClientScope(testCtx, realmId, clientScopeId)
+			if clientScope != nil {
+				return fmt.Errorf("optional client scope mapping with id %s still exists", id)
+			}
+		}
+
+		return nil
+	}
+}
+
+func getKeycloakOpenidOptionalClientScopeImportId(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource %s not found", resourceName)
+		}
+
+		id := rs.Primary.ID
+
+		return id, nil
+	}
+}
+
+func testAccCheckKeycloakOpenidClientHasOptionalScope() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		resourceName := "keycloak_openid_optional_client_scope.openid_optional_client_scope"
+		rsClientScope, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		resourceName = "keycloak_openid_client.openid_client"
+		rsClient, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		realm := rsClientScope.Primary.Attributes["realm_id"]
+		clientScopeId := rsClientScope.Primary.Attributes["client_scope_id"]
+
+		clientId := rsClient.Primary.ID
+
+		keycloakOptionalClientScopes, err := keycloakClient.GetOpenidClientOptionalScopes(testCtx, realm, clientId)
+
+		if err != nil {
+			return err
+		}
+
+		var found = false
+		for _, keycloakOptionalScope := range keycloakOptionalClientScopes {
+			if keycloakOptionalScope.Id == clientScopeId {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("default scope %s is not assigned to client", clientScopeId)
+		}
+
+		return nil
+	}
+}
+
+func testAccKeycloakOpenidOptionalClientScopeConfig(clientId string, clientScopeId string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client_scope" "openid_client_scope" {
+  realm_id = data.keycloak_realm.realm.id
+  name     = "%s"
+}
+
+resource "keycloak_openid_optional_client_scope" "openid_optional_client_scope" {
+	realm_id        = data.keycloak_realm.realm.id
+	client_scope_id = keycloak_openid_client_scope.openid_client_scope.id
+}
+
+resource "keycloak_openid_client" "openid_client" {
+	realm_id    = data.keycloak_realm.realm.id
+	client_id   = "%s"
+	access_type = "CONFIDENTIAL"
+	depends_on  = [keycloak_openid_optional_client_scope.openid_optional_client_scope]
+}
+`, testAccRealm.Realm, clientScopeId, clientId)
+}


### PR DESCRIPTION
Replaces #649 (Closes #649) 
Relates #895 #470 #547

This PR adds two new resources to the Terraform Keycloak provider: `keycloak_openid_default_client_scope` and `keycloak_openid_optional_client_scope`. These resources allow assigning default or optional client scopes at the realm level, resolving a significant limitation. While default client scopes can already be configured at the realm level, custom-created scopes are not supported due to a chicken-and-egg issue: custom scopes require the realm to exist beforehand. Moreover, these resources enable fine-grained management of individual client scopes rather than managing an entire list, providing enhanced flexibility and precision.

Thanks to @Korsarro69 for the initial work. I opened this PR as #649 is now stale.

cc @daviddelannoy @dglozano @lebronnecf

TODO:
- [ ] Naming clarification:  Current client scope mapping resources are called `keycloak_openid_client_default_scopes` and `keycloak_openid_client_optional_scopes`. Isn't `keycloak_openid_default_client_scope` and `keycloak_openid_optional_client_scope` not too confusing? Should I rename to `keycloak_openid_client_default_scope` and `keycloak_openid_client_optional_scope`? I guess the real-wide will be added to the list resources in the future, which will align functionalities.
- [ ] Fix/Add tests

Run tests in codespaces with:
```shell
sudo apt update
sudo apt-get install -y openjdk-11-jdk
make user-federation-example
make local
export KEYCLOAK_CLIENT_ID=terraform \
KEYCLOAK_CLIENT_SECRET=884e0f95-0f42-4a63-9b1f-94274655669e \
KEYCLOAK_CLIENT_TIMEOUT=5 \
KEYCLOAK_REALM=master \
KEYCLOAK_URL="http://localhost:8080"
make testacc TESTARGS='-run "DefaultClientScope|OptionalClientScope"'
```