### PR TITLE
feat: allow configuration of display_name for oidc identity providers

### DIFF
--- a/provider/resource_keycloak_oidc_google_identity_provider.go
+++ b/provider/resource_keycloak_oidc_google_identity_provider.go
@@ -17,8 +17,9 @@ func resourceKeycloakOidcGoogleIdentityProvider() *schema.Resource {
 		},
 		"display_name": {
 			Type:        schema.TypeString,
+			Optional:    true,
 			Computed:    true,
-			Description: "Not used by this provider, Will be implicitly Google",
+			Description: "The human-friendly name of the identity provider, used in the log in form.",
 		},
 		"provider_id": {
 			Type:        schema.TypeString,

--- a/provider/resource_keycloak_oidc_google_identity_provider_test.go
+++ b/provider/resource_keycloak_oidc_google_identity_provider_test.go
@@ -31,6 +31,35 @@ func TestAccKeycloakOidcGoogleIdentityProvider_basic(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakOidcGoogleIdentityProvider_customDisplayName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOidcGoogleIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_oidc_google_identity_provider" "google" {
+	realm             = data.keycloak_realm.realm.id
+	client_id         = "example_id"
+	client_secret     = "example_token"
+
+	display_name = "Example Google"
+}
+	`, testAccRealm.Realm),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOidcGoogleIdentityProviderExists("keycloak_oidc_google_identity_provider.google"),
+					resource.TestCheckResourceAttr("keycloak_oidc_google_identity_provider.google", "display_name", "Example Google"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakOidcGoogleIdentityProvider_extraConfig(t *testing.T) {
 	customConfigValue := acctest.RandomWithPrefix("tf-acc")
 

--- a/provider/resource_keycloak_oidc_identity_provider.go
+++ b/provider/resource_keycloak_oidc_identity_provider.go
@@ -16,6 +16,12 @@ func resourceKeycloakOidcIdentityProvider() *schema.Resource {
 			Default:     "oidc",
 			Description: "provider id, is always oidc, unless you have a custom implementation",
 		},
+		"display_name": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "The human-friendly name of the identity provider, used in the log in form.",
+		},
 		"backchannel_supported": {
 			Type:        schema.TypeBool,
 			Optional:    true,

--- a/provider/resource_keycloak_oidc_identity_provider_test.go
+++ b/provider/resource_keycloak_oidc_identity_provider_test.go
@@ -30,6 +30,44 @@ func TestAccKeycloakOidcIdentityProvider_basic(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakOidcIdentityProvider_customDisplayName(t *testing.T) {
+	t.Parallel()
+
+	oidcName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOidcIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_oidc_identity_provider" "oidc" {
+	realm             = data.keycloak_realm.realm.id
+	alias             = "%s"
+	authorization_url = "https://example.com/auth"
+	token_url         = "https://example.com/token"
+	client_id         = "example_id"
+	client_secret     = "example_token"
+
+	issuer = "hello"
+
+	display_name = "Example Provider"
+}
+	`, testAccRealm.Realm, oidcName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOidcIdentityProviderExists("keycloak_oidc_identity_provider.oidc"),
+					resource.TestCheckResourceAttr("keycloak_oidc_identity_provider.oidc", "display_name", "Example Provider"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakOidcIdentityProvider_extraConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
I'm glad I've found something that allows me to contribute to this provider, as it's something I've been using for a really long time.

Came across this issue earlier today - this change allows users to configure the display name of OIDC and Google OIDC identity providers.

Resolves #639 