### PR TITLE
Fixed examples and user-federation-example

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   go-dependency-submission:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   wait:
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Wait for acceptance tests
     steps:
       - name: Wait for acceptance tests
@@ -25,7 +25,7 @@ jobs:
     permissions: write-all
     needs:
       - wait
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
       (needs.verify.outputs.code-files-changed || startsWith(github.ref, 'refs/tags/v'))
     needs:
       - verify
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         keycloak-version:

--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ KEYCLOAK_URL="http://localhost:8080" \
 make testacc
 ```
 
+### Run examples
+
+You can run examples against a Keycloak instance.
+Follow the commands for running examples against a local environment that was created via `make local`:
+
+```
+make build-example
+cd example
+terraform init
+terraform plan -out tfplan
+terraform apply tfplan
+rm tfplan
+```
+
 ## Acknowledgments
 
 The Keycloak Terraform Provider was originally created by [Michael Parker](https://github.com/mrparkers). Many thanks for the hard work and dedication in building the foundation for this project.

--- a/custom-user-federation-example/build.gradle
+++ b/custom-user-federation-example/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 ext {
-	keycloakVersion = '21.0.1'
+	keycloakVersion = '25.0.3'
 }
 
 dependencies {
@@ -18,5 +18,5 @@ repositories {
 }
 
 kotlin {
-	jvmToolchain(11)
+	jvmToolchain(21)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
     - postgres
     - openldap
     environment:
-    - KEYCLOAK_ADMIN=keycloak
-    - KEYCLOAK_ADMIN_PASSWORD=password
+    - KC_BOOTSTRAP_ADMIN_USERNAME=keycloak
+    - KC_BOOTSTRAP_ADMIN_PASSWORD=password
     - KC_LOG_LEVEL=INFO
     - KC_DB=postgres
     - KC_DB_URL_HOST=postgres
@@ -29,6 +29,11 @@ services:
     - KC_DB_URL_DATABASE=keycloak
     - KC_DB_USERNAME=keycloak
     - KC_DB_PASSWORD=password
+    - KC_LOG_LEVEL=INFO
+    - KC_LOG_CONSOLE_COLOR=true
+    - KC_FEATURES=preview
+    - QUARKUS_HTTP_ACCESS_LOG_ENABLED=true
+    - QUARKUS_HTTP_RECORD_REQUEST_START_TIME=true
 # Enable for remote java debugging
 #    - PREPEND_JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8787
     ports:

--- a/example/main.tf
+++ b/example/main.tf
@@ -1096,6 +1096,14 @@ resource "keycloak_realm_user_profile" "userprofile" {
   realm_id = keycloak_realm.test.id
 
   attribute {
+    name = "username"
+  }
+
+  attribute {
+    name = "email"
+  }
+
+  attribute {
     name         = "field1"
     display_name = "Field 1"
     group        = "group1"

--- a/example/roles.tf
+++ b/example/roles.tf
@@ -58,7 +58,7 @@ resource "keycloak_role" "pet_api_read_pet_details" {
 }
 
 // Map a role from the "pet_api" api client to the "extended_pet_details" client scope
-resource "keycloak_generic_client_role_mapper" "pet_api_read_pet_details_role_mapping" {
+resource "keycloak_generic_role_mapper" "pet_api_read_pet_details_role_mapping" {
   realm_id  = keycloak_realm.roles_example.id
   client_scope_id = keycloak_openid_client_scope.extended_pet_details.id
   role_id   = keycloak_role.pet_api_read_pet_details.id
@@ -98,7 +98,7 @@ resource "keycloak_openid_client" "pet_app" {
     "http://localhost:5555/openid-callback",
   ]
 
-  // disable full scope, roles are assigned via keycloak_generic_client_role_mapper
+  // disable full scope, roles are assigned via keycloak_generic_role_mapper
   full_scope_allowed = false
 }
 
@@ -130,31 +130,31 @@ resource "keycloak_openid_hardcoded_role_protocol_mapper" "pet_app_pet_api_read_
 }
 
 // Map all roles from the "pet_api" api client to the "pet_app" consumer client, read_pet_details comes via client scope
-resource "keycloak_generic_client_role_mapper" "pet_app_pet_api_read_role_mapping" {
+resource "keycloak_generic_role_mapper" "pet_app_pet_api_read_role_mapping" {
   realm_id  = keycloak_realm.roles_example.id
   client_id = keycloak_openid_client.pet_app.id
   role_id   = keycloak_role.pet_api_read_pet.id
 }
 
-resource "keycloak_generic_client_role_mapper" "pet_app_pet_api_delete_role_mapping" {
+resource "keycloak_generic_role_mapper" "pet_app_pet_api_delete_role_mapping" {
   realm_id  = keycloak_realm.roles_example.id
   client_id = keycloak_openid_client.pet_app.id
   role_id   = keycloak_role.pet_api_delete_pet.id
 }
 
-resource "keycloak_generic_client_role_mapper" "pet_app_pet_api_create_role_mapping" {
+resource "keycloak_generic_role_mapper" "pet_app_pet_api_create_role_mapping" {
   realm_id  = keycloak_realm.roles_example.id
   client_id = keycloak_openid_client.pet_app.id
   role_id   = keycloak_role.pet_api_create_pet.id
 }
 
-resource "keycloak_generic_client_role_mapper" "pet_app_pet_api_update_role_mapping" {
+resource "keycloak_generic_role_mapper" "pet_app_pet_api_update_role_mapping" {
   realm_id  = keycloak_realm.roles_example.id
   client_id = keycloak_openid_client.pet_app.id
   role_id   = keycloak_role.pet_api_update_pet.id
 }
 
-resource "keycloak_generic_client_role_mapper" "pet_app_pet_api_admin_role_mapping" {
+resource "keycloak_generic_role_mapper" "pet_app_pet_api_admin_role_mapping" {
   realm_id  = keycloak_realm.roles_example.id
   client_id = keycloak_openid_client.pet_app.id
   role_id   = keycloak_role.pet_api_admin.id
@@ -162,7 +162,7 @@ resource "keycloak_generic_client_role_mapper" "pet_app_pet_api_admin_role_mappi
 
 // Realm roles
 
-resource "keycloak_role" "realm_reader" {  
+resource "keycloak_role" "realm_reader" {
   realm_id  = keycloak_realm.roles_example.id
   name        = "realm_reader"
   description = "Reader realm role"
@@ -184,7 +184,7 @@ resource "keycloak_role" "realm_admin" {
   ]
 }
 
-// Client scope for realm roles mapping 
+// Client scope for realm roles mapping
 
 resource "keycloak_openid_client_scope" "petstore_api_access_scope" {
   realm_id  = keycloak_realm.roles_example.id
@@ -192,7 +192,7 @@ resource "keycloak_openid_client_scope" "petstore_api_access_scope" {
   description = "Optional scope offering additional information for petstore api access"
 }
 
-resource "keycloak_generic_client_role_mapper" "petstore_api_access_scope_admin" {
+resource "keycloak_generic_role_mapper" "petstore_api_access_scope_admin" {
     realm_id  = keycloak_realm.roles_example.id
     client_scope_id =  keycloak_openid_client_scope.petstore_api_access_scope.id
     role_id         = keycloak_role.realm_admin.id

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ build-example: build
 	cp terraform-provider-keycloak_* example/.terraform/plugins/terraform.local/keycloak/keycloak/4.5.0/$(GOOS)_$(GOARCH)/
 	cp terraform-provider-keycloak_* example/terraform.d/plugins/terraform.local/keycloak/keycloak/4.5.0/$(GOOS)_$(GOARCH)/
 
-local: deps
+local: deps user-federation-example
 	docker compose up --build -d
 	./scripts/wait-for-local-keycloak.sh
 	./scripts/create-terraform-client.sh


### PR DESCRIPTION
* Added `user-federation-example` target to `make local`
* Fixed `custom-user-federation-example` by using dependencies in version 25.0.3 (More refactoring is necessary to compile it with 26.0.7)
* Fixed examples when running against KC 26.0.7 (There was an error regarding user-profile and deprecation warnings)
* Eliminated warns regarding usage of ubuntu-latest in CI 