### PR TITLE
Prevent force replacing resources when `import` value in state is nil

### DIFF
--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -571,6 +571,10 @@ func resourceKeycloakOpenidClientRead(ctx context.Context, data *schema.Resource
 		return diag.FromErr(err)
 	}
 
+	if _, ok := data.GetOk("import"); !ok {
+		data.Set("import", false)
+	}
+
 	return nil
 }
 

--- a/provider/resource_keycloak_role.go
+++ b/provider/resource_keycloak_role.go
@@ -213,6 +213,10 @@ func resourceKeycloakRoleRead(ctx context.Context, data *schema.ResourceData, me
 		data.Set("composite_roles", compositeRoleIds)
 	}
 
+	if _, ok := data.GetOk("import"); !ok {
+		data.Set("import", false)
+	}
+
 	return nil
 }
 

--- a/provider/resource_keycloak_user.go
+++ b/provider/resource_keycloak_user.go
@@ -264,6 +264,10 @@ func resourceKeycloakUserRead(ctx context.Context, data *schema.ResourceData, me
 
 	mapFromUserToData(data, user)
 
+	if _, ok := data.GetOk("import"); !ok {
+		data.Set("import", false)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes #1053. I believe that Terraform state older than v4.0.0 with `keycloak_openid_client` resources is also impacted by this, so I've tried to address include a fix for those as well.