### PR TITLE
Add attribute_force_default to ldap_user_attribute_mapper

### DIFF
--- a/docs/resources/ldap_user_attribute_mapper.md
+++ b/docs/resources/ldap_user_attribute_mapper.md
@@ -56,6 +56,7 @@ resource "keycloak_ldap_user_attribute_mapper" "ldap_user_attribute_mapper" {
 - `read_only` - (Optional) When `true`, this attribute is not saved back to LDAP when the user attribute is updated in Keycloak. Defaults to `false`.
 - `always_read_value_from_ldap` - (Optional) When `true`, the value fetched from LDAP will override the value stored in Keycloak. Defaults to `false`.
 - `is_mandatory_in_ldap` - (Optional) When `true`, this attribute must exist in LDAP. Defaults to `false`.
+- `attribute_force_default` - (Optional) When `true`, an empty default value is forced for mandatory attributes even when a default value is not specified. Defaults to `true`.
 - `attribute_default_value` - (Optional) Default value to set in LDAP if `is_mandatory_in_ldap` is true and the value is empty.
 - `is_binary_attribute` - (Optional) Should be true for binary LDAP attributes.
 

--- a/keycloak/ldap_user_attribute_mapper.go
+++ b/keycloak/ldap_user_attribute_mapper.go
@@ -17,6 +17,7 @@ type LdapUserAttributeMapper struct {
 	ReadOnly                bool
 	AlwaysReadValueFromLdap bool
 	UserModelAttribute      string
+	ForceDefaultValue       bool
 	AttributeDefaultValue   string
 	IsBinaryAttribute       bool
 }
@@ -44,6 +45,9 @@ func convertFromLdapUserAttributeMapperToComponent(ldapUserAttributeMapper *Ldap
 			"user.model.attribute": {
 				ldapUserAttributeMapper.UserModelAttribute,
 			},
+			"attribute.force.default": {
+				strconv.FormatBool(ldapUserAttributeMapper.ForceDefaultValue),
+			},
 			"attribute.default.value": {
 				ldapUserAttributeMapper.AttributeDefaultValue,
 			},
@@ -70,6 +74,11 @@ func convertFromComponentToLdapUserAttributeMapper(component *component, realmId
 		return nil, err
 	}
 
+	forceDefaultValue, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("attribute.force.default"))
+	if err != nil {
+		return nil, err
+	}
+
 	isBinaryAttribute, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("is.binary.attribute"))
 	if err != nil {
 		return nil, err
@@ -86,6 +95,7 @@ func convertFromComponentToLdapUserAttributeMapper(component *component, realmId
 		ReadOnly:                readOnly,
 		AlwaysReadValueFromLdap: alwaysReadValueFromLdap,
 		UserModelAttribute:      component.getConfig("user.model.attribute"),
+		ForceDefaultValue:       forceDefaultValue,
 		AttributeDefaultValue:   component.getConfig("attribute.default.value"),
 		IsBinaryAttribute:       isBinaryAttribute,
 	}, nil

--- a/provider/resource_keycloak_ldap_user_attribute_mapper.go
+++ b/provider/resource_keycloak_ldap_user_attribute_mapper.go
@@ -64,6 +64,12 @@ func resourceKeycloakLdapUserAttributeMapper() *schema.Resource {
 				Default:     false,
 				Description: "When true, this attribute must exist in LDAP.",
 			},
+			"attribute_force_default": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "When true, an empty default value is forced for mandatory attributes even when a default value is not specified.",
+			},
 			"attribute_default_value": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -93,6 +99,7 @@ func getLdapUserAttributeMapperFromData(data *schema.ResourceData) *keycloak.Lda
 		ReadOnly:                data.Get("read_only").(bool),
 		AlwaysReadValueFromLdap: data.Get("always_read_value_from_ldap").(bool),
 		IsMandatoryInLdap:       data.Get("is_mandatory_in_ldap").(bool),
+		ForceDefaultValue:       data.Get("attribute_force_default").(bool),
 		AttributeDefaultValue:   data.Get("attribute_default_value").(string),
 		IsBinaryAttribute:       data.Get("is_binary_attribute").(bool),
 	}
@@ -111,6 +118,7 @@ func setLdapUserAttributeMapperData(data *schema.ResourceData, ldapUserAttribute
 	data.Set("read_only", ldapUserAttributeMapper.ReadOnly)
 	data.Set("always_read_value_from_ldap", ldapUserAttributeMapper.AlwaysReadValueFromLdap)
 	data.Set("is_mandatory_in_ldap", ldapUserAttributeMapper.IsMandatoryInLdap)
+	data.Set("attribute_force_default", ldapUserAttributeMapper.ForceDefaultValue)
 	data.Set("attribute_default_value", ldapUserAttributeMapper.AttributeDefaultValue)
 	data.Set("is_binary_attribute", ldapUserAttributeMapper.IsBinaryAttribute)
 }

--- a/provider/resource_keycloak_ldap_user_attribute_mapper_test.go
+++ b/provider/resource_keycloak_ldap_user_attribute_mapper_test.go
@@ -96,6 +96,7 @@ func TestAccKeycloakLdapUserAttributeMapper_updateInPlace(t *testing.T) {
 		IsMandatoryInLdap:       randomBool(),
 		ReadOnly:                randomBool(),
 		AlwaysReadValueFromLdap: true,
+		ForceDefaultValue:       randomBool(),
 		AttributeDefaultValue:   acctest.RandString(10),
 		IsBinaryAttribute:       randomBool(),
 	}
@@ -105,6 +106,7 @@ func TestAccKeycloakLdapUserAttributeMapper_updateInPlace(t *testing.T) {
 		LdapAttribute:           acctest.RandString(10),
 		IsMandatoryInLdap:       randomBool(),
 		ReadOnly:                randomBool(),
+		ForceDefaultValue:       randomBool(),
 		AlwaysReadValueFromLdap: randomBool(),
 		AttributeDefaultValue:   acctest.RandString(10),
 		IsBinaryAttribute:       false,
@@ -261,11 +263,12 @@ resource "keycloak_ldap_user_attribute_mapper" "username" {
 	read_only                   = %t
 	always_read_value_from_ldap = %t
 	is_mandatory_in_ldap        = %t
+	attribute_force_default     = "%t"
 	attribute_default_value     = "%s"
 	is_binary_attribute         = %t
 }
 	`, testAccRealmUserFederation.Realm, mapper.Name, mapper.UserModelAttribute, mapper.LdapAttribute, mapper.ReadOnly, mapper.AlwaysReadValueFromLdap, mapper.IsMandatoryInLdap,
-		mapper.AttributeDefaultValue, mapper.IsBinaryAttribute)
+		mapper.ForceDefaultValue, mapper.AttributeDefaultValue, mapper.IsBinaryAttribute)
 }
 
 func testKeycloakLdapUserAttributeMapper_updateLdapUserFederationBefore(userAttributeMapperName string) string {


### PR DESCRIPTION
The `ldap_user_attribute_mapper` is missing a parameter to control the "Force a Default Value" setting.