### PR TITLE
chore: Ignore local scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ terraform.d/
 .terraform.lock.hcl
 terraform.tfstate*
 
+# local experiments or reproducers
+scratch/
+
 .gradle/
 
 # custom user federation example


### PR DESCRIPTION
We can use scratch/ for local experiments or reproducers.