### PR TITLE
feat: add all supported alogithms for rsa-enc keystore

### DIFF
--- a/provider/resource_keycloak_realm_keystore_java_keystore.go
+++ b/provider/resource_keycloak_realm_keystore_java_keystore.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -9,7 +10,7 @@ import (
 )
 
 var (
-	keycloakRealmKeystoreJavaKeystoreAlgorithm = []string{"RS256", "RS384", "RS512", "PS256", "PS384", "PS512"}
+	keycloakRealmKeystoreJavaKeystoreAlgorithm = []string{"AES", "EdDSA", "ES256", "ES384", "ES512", "HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "RSA1_5", "RSA-OAEP", "RSA-OAEP-256", "ECDH-ES", "ECDH-ES+A128KW", "ECDH-ES+A192KW", "ECDH-ES+A256KW"}
 )
 
 func resourceKeycloakRealmKeystoreJavaKeystore() *schema.Resource {

--- a/provider/resource_keycloak_realm_keystore_java_kyestore_test.go
+++ b/provider/resource_keycloak_realm_keystore_java_kyestore_test.go
@@ -2,13 +2,14 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/keycloak/terraform-provider-keycloak/keycloak"
-	"regexp"
-	"strconv"
-	"testing"
 )
 
 func TestAccKeycloakRealmKeystoreJava_basic(t *testing.T) {
@@ -74,7 +75,7 @@ func TestAccKeycloakRealmKeystoreJava_algorithmValidation(t *testing.T) {
 
 	skipIfEnvSet(t, "CI") // temporary while I figure out how to put java keystore file to keycloak container in CI
 
-	algorithm := randomStringInSlice(keycloakRealmKeystoreRsaAlgorithm)
+	algorithm := randomStringInSlice(keycloakRealmKeystoreJavaKeystoreAlgorithm)
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,

--- a/provider/resource_keycloak_realm_keystore_rsa.go
+++ b/provider/resource_keycloak_realm_keystore_rsa.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -9,7 +10,8 @@ import (
 )
 
 var (
-	keycloakRealmKeystoreRsaAlgorithm = []string{"RS256", "RS384", "RS512", "PS256", "PS384", "PS512", "RSA-OAEP"}
+	keycloakRealmKeystoreRsaAlgorithm    = []string{"RS256", "RS384", "RS512", "PS256", "PS384", "PS512"}
+	keycloakRealmKeystoreRsaEncAlgorithm = []string{"RSA1_5", "RSA-OAEP", "RSA-OAEP-256"}
 )
 
 func resourceKeycloakRealmKeystoreRsa() *schema.Resource {
@@ -53,7 +55,7 @@ func resourceKeycloakRealmKeystoreRsa() *schema.Resource {
 			"algorithm": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice(keycloakRealmKeystoreRsaAlgorithm, false),
+				ValidateFunc: validation.StringInSlice(append(keycloakRealmKeystoreRsaAlgorithm, keycloakRealmKeystoreRsaEncAlgorithm...), false),
 				Default:      "RS256",
 				Description:  "Intended algorithm for the key",
 			},


### PR DESCRIPTION
This PR adds simply all algorithms which are available for keystores based on rsa-enc provider. Currently it got only a single one while there are 3 different available.