### PR TITLE
fix: Render json `null` to indicate an empty value of type KeycloakSliceHashDelimited (#1142).

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,14 +22,13 @@ services:
     environment:
     - KC_BOOTSTRAP_ADMIN_USERNAME=keycloak
     - KC_BOOTSTRAP_ADMIN_PASSWORD=password
-    - KC_LOG_LEVEL=INFO
+    - KC_LOG_LEVEL=INFO,org.keycloak:debug
     - KC_DB=postgres
     - KC_DB_URL_HOST=postgres
     - KC_DB_URL_PORT=5432
     - KC_DB_URL_DATABASE=keycloak
     - KC_DB_USERNAME=keycloak
     - KC_DB_PASSWORD=password
-    - KC_LOG_LEVEL=INFO
     - KC_LOG_CONSOLE_COLOR=true
     - KC_FEATURES=preview
     - QUARKUS_HTTP_ACCESS_LOG_ENABLED=true

--- a/keycloak/types/keycloak_slice_hash_delimited.go
+++ b/keycloak/types/keycloak_slice_hash_delimited.go
@@ -12,7 +12,8 @@ type KeycloakSliceHashDelimited []string
 func (s KeycloakSliceHashDelimited) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
 	if s == nil || len(s) == 0 {
-		buf.WriteString(`""`)
+		// Allows omitempty to work
+		return []byte("null"), nil
 	} else {
 		buf.WriteString(`"`)
 

--- a/keycloak/types/keycloak_slice_hash_delimited_test.go
+++ b/keycloak/types/keycloak_slice_hash_delimited_test.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestKeycloakSliceHashDelimited_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		s       KeycloakSliceHashDelimited
+		want    []byte
+		wantErr bool
+	}{
+		{"should render null for nil slice", nil, []byte("null"), false},
+		{"should render single item", KeycloakSliceHashDelimited{"https://app/redirect1"}, []byte("\"https://app/redirect1\""), false},
+		{"should render two items", KeycloakSliceHashDelimited{"https://app/redirect1", "https://app/redirect2"}, []byte("\"https://app/redirect1##https://app/redirect2\""), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.s.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MarshalJSON() got = %v, want %v", string(got), string(tt.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, `KeycloakSliceHashDelimited` rendered an empty `""` string for a `nil` slice, which resulted in an attribute value being created in Keycloak. The empty `""`attribute then caused issues during validation of `Post Logout URIs`. We now emit a `null` value  to indicate a missing value, the null value is then ignored by Keycloak when creating / updating the client.

Note to explicitly override an set an empty value, an empty slice can be used, e.g:
```
valid_post_logout_redirect_uris = []
```

Fixes #1142