### PR TITLE
Retry on timeout, when server doesn't respond

### DIFF
--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -499,6 +499,30 @@ func (keycloakClient *KeycloakClient) marshal(body interface{}) ([]byte, error) 
 	return json.Marshal(body)
 }
 
+func RetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	// do not retry on context.Canceled or context.DeadlineExceeded
+	if ctx.Err() != nil {
+		return true, ctx.Err()
+	}
+
+	// 429 Too Many Requests is recoverable. Sometimes the server puts
+	// a Retry-After response header to indicate when the server is
+	// available to start processing request from client.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return true, nil
+	}
+
+	// Check the response code. We retry on 500-range responses to allow
+	// the server time to recover, as 500's are typically not permanent
+	// errors and may relate to outages on the server side. This will catch
+	// invalid response codes as well, like 0 and 999.
+	if resp.StatusCode == 0 || (resp.StatusCode >= 500 && resp.StatusCode != http.StatusNotImplemented) {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func newHttpClient(tlsInsecureSkipVerify bool, clientTimeout int, caCert string) (*http.Client, error) {
 	cookieJar, err := cookiejar.New(&cookiejar.Options{
 		PublicSuffixList: publicsuffix.List,
@@ -519,9 +543,10 @@ func newHttpClient(tlsInsecureSkipVerify bool, clientTimeout int, caCert string)
 	}
 
 	retryClient := retryablehttp.NewClient()
-	retryClient.RetryMax = 1
+	retryClient.CheckRetry = RetryPolicy
+	retryClient.RetryMax = 5
 	retryClient.RetryWaitMin = time.Second * 1
-	retryClient.RetryWaitMax = time.Second * 3
+	retryClient.RetryWaitMax = time.Second * 60
 
 	httpClient := retryClient.StandardClient()
 	httpClient.Timeout = time.Second * time.Duration(clientTimeout)

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -500,7 +500,7 @@ func (keycloakClient *KeycloakClient) marshal(body interface{}) ([]byte, error) 
 }
 
 func RetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
-	// do not retry on context.Canceled or context.DeadlineExceeded
+	// do retry on context.Canceled or context.DeadlineExceeded
 	if ctx.Err() != nil {
 		return true, ctx.Err()
 	}


### PR DESCRIPTION
Hello

Under load, the keycloak server doesn't respond. The requests done by terraform timeout and are not retried.

This MR force the retry of timeout requests and increase the number of retry.

Thank you for this great provider
Romain