### PR TITLE
Increase MaxIdleConnsPerHost in http.Transport

### DIFF
--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -535,6 +535,7 @@ func newHttpClient(tlsInsecureSkipVerify bool, clientTimeout int, caCert string)
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: tlsInsecureSkipVerify},
 		Proxy:           http.ProxyFromEnvironment,
 	}
+	transport.MaxIdleConnsPerHost = 100
 
 	if caCert != "" {
 		caCertPool := x509.NewCertPool()


### PR DESCRIPTION
The default behaviour of http.Transport does not handle the use case of "many concurrent requests against a single host" very well.

By default, it will only keep 2 persistent connections in the pool. Everything above that is burst capacity, and those connections are closed. The result is a lot of connection churn, which can lead to port exhaustion (especially on more constrained resources like a shared NAT).

Increase the idle pool from 2 to 100, allowing for more connection reuse and in turn reducing connection churn.