### PR TITLE
Allow the alias of Google IdP to be set

### DIFF
--- a/docs/resources/oidc_google_identity_provider.md
+++ b/docs/resources/oidc_google_identity_provider.md
@@ -35,6 +35,8 @@ resource "keycloak_oidc_google_identity_provider" "google" {
 - `realm` - (Required) The name of the realm. This is unique across Keycloak.
 - `client_id` - (Required) The client or client identifier registered within the identity provider.
 - `client_secret` - (Required) The client or client secret registered within the identity provider. This field is able to obtain its value from vault, use $${vault.ID} format.
+- `alias` - (Optional) The alias for the Google identity provider.
+- `display_name` - (Optional) Display name for the Google identity provider in the GUI.
 - `enabled` - (Optional) When `true`, users will be able to log in to this realm using this identity provider. Defaults to `true`.
 - `store_token` - (Optional) When `true`, tokens will be stored after authenticating users. Defaults to `true`.
 - `add_read_token_role_on_create` - (Optional) When `true`, new users will be able to read stored tokens. This will automatically assign the `broker.read-token` role. Defaults to `false`.
@@ -57,8 +59,6 @@ resource "keycloak_oidc_google_identity_provider" "google" {
 ## Attribute Reference
 
 - `internal_id` - (Computed) The unique ID that Keycloak assigns to the identity provider upon creation.
-- `alias` - (Computed) The alias for the Google identity provider.
-- `display_name` - (Computed) Display name for the Google identity provider in the GUI.
 
 ## Import
 

--- a/provider/resource_keycloak_oidc_google_identity_provider.go
+++ b/provider/resource_keycloak_oidc_google_identity_provider.go
@@ -12,6 +12,7 @@ func resourceKeycloakOidcGoogleIdentityProvider() *schema.Resource {
 	oidcGoogleSchema := map[string]*schema.Schema{
 		"alias": {
 			Type:        schema.TypeString,
+			Optional:    true,
 			Computed:    true,
 			Description: "The alias uniquely identifies an identity provider and it is also used to build the redirect uri. In case of google this is computed and always google",
 		},
@@ -91,7 +92,13 @@ func resourceKeycloakOidcGoogleIdentityProvider() *schema.Resource {
 func getOidcGoogleIdentityProviderFromData(data *schema.ResourceData, keycloakVersion *version.Version) (*keycloak.IdentityProvider, error) {
 	rec, defaultConfig := getIdentityProviderFromData(data, keycloakVersion)
 	rec.ProviderId = data.Get("provider_id").(string)
-	rec.Alias = "google"
+
+	aliasRaw, ok := data.GetOk("alias")
+	if ok {
+		rec.Alias = aliasRaw.(string)
+	} else {
+		rec.Alias = "google"
+	}
 
 	googleOidcIdentityProviderConfig := &keycloak.IdentityProviderConfig{
 		ClientId:                    data.Get("client_id").(string),

--- a/provider/resource_keycloak_oidc_google_identity_provider_test.go
+++ b/provider/resource_keycloak_oidc_google_identity_provider_test.go
@@ -2,14 +2,15 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/keycloak/terraform-provider-keycloak/keycloak"
 	"github.com/keycloak/terraform-provider-keycloak/keycloak/types"
-	"regexp"
-	"strconv"
-	"testing"
 )
 
 /*
@@ -26,6 +27,35 @@ func TestAccKeycloakOidcGoogleIdentityProvider_basic(t *testing.T) {
 			{
 				Config: testKeycloakOidcGoogleIdentityProvider_basic(),
 				Check:  testAccCheckKeycloakOidcGoogleIdentityProviderExists("keycloak_oidc_google_identity_provider.google"),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOidcGoogleIdentityProvider_customAlias(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOidcGoogleIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_oidc_google_identity_provider" "google" {
+	realm             = data.keycloak_realm.realm.id
+	client_id         = "example_id"
+	client_secret     = "example_token"
+
+	alias = "example"
+}
+	`, testAccRealm.Realm),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOidcGoogleIdentityProviderExists("keycloak_oidc_google_identity_provider.google"),
+					resource.TestCheckResourceAttr("keycloak_oidc_google_identity_provider.google", "alias", "example"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
Resolves #1164 

Allows the `alias` property of the Google IdP to be configured.