### PR TITLE
Add RSA_SHAxxx_MGF1 signature algorithms to SAML identity provider config

### DIFF
--- a/provider/resource_keycloak_saml_identity_provider.go
+++ b/provider/resource_keycloak_saml_identity_provider.go
@@ -22,7 +22,9 @@ var nameIdPolicyFormats = map[string]string{
 var signatureAlgorithms = []string{
 	"RSA_SHA1",
 	"RSA_SHA256",
+	"RSA_SHA256_MGF1",
 	"RSA_SHA512",
+	"RSA_SHA512_MGF1",
 	"DSA_SHA1",
 }
 


### PR DESCRIPTION
Both RSA_SHA256_MGF1 and RSA_SHA512_MGF1 have been supported by Keycloak since https://github.com/keycloak/keycloak/pull/7480.

#757 added them to the client configuration in Terraform, this PR also allows SAML identity providers to use those signature algorithms.