### PR TITLE
Docs: Updated Markdown to format correctly

### DIFF
--- a/docs/data-sources/openid_client_service_account_user.md
+++ b/docs/data-sources/openid_client_service_account_user.md
@@ -55,10 +55,10 @@ resource "keycloak_user_roles" "service_account_user_roles" {
 
 ## Attributes Reference
 
-`username` - (Computed) The service account user's username.
-`email` - (Computed) The service account user's email.
-`first_name` - (Computed) The service account user's first name.
-`last_name` - (Computed) The service account user's last name.
-`enabled` - (Computed) Whether the service account user is enabled.
-`attributes` - (Computed) The service account user's attributes.
-`federated_identity` - (Computed) This attribute exists in order to adhere to the spec of a Keycloak user, but a service account user will never have a federated identity, so this will always be `null`.
+`username` - (Computed) The service account user's username.  
+`email` - (Computed) The service account user's email.  
+`first_name` - (Computed) The service account user's first name.  
+`last_name` - (Computed) The service account user's last name.  
+`enabled` - (Computed) Whether the service account user is enabled.  
+`attributes` - (Computed) The service account user's attributes.  
+`federated_identity` - (Computed) This attribute exists in order to adhere to the spec of a Keycloak user, but a service account user will never have a federated identity, so this will always be `null`.  


### PR DESCRIPTION
On the page https://registry.terraform.io/providers/keycloak/keycloak/latest/docs/data-sources/openid_client_service_account_user

the Attributed Reference displays as one block with no page breaks. This PR adds two spaces to the end of each line to ensure the docs format correctly

![image](https://github.com/user-attachments/assets/81a501c0-8d93-48f7-9203-ac977cf41e8f)
