### PR TITLE
optimize resolving `ParentId` property with group-by-path API

### DIFF
--- a/keycloak/group.go
+++ b/keycloak/group.go
@@ -3,6 +3,7 @@ package keycloak
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 )
 
@@ -19,44 +20,24 @@ type Group struct {
 }
 
 /*
- * There is no way to get a subgroup's parent ID using the Keycloak API (that I know of, PRs are welcome)
- * The best we can do is check subGroup's path with the group's path to figure out what sub-path to follow
- * until we find it.
+ * Resolve a subgroup's parent ID using the Keycloak group-by-path API
  */
 func (keycloakClient *KeycloakClient) groupParentId(ctx context.Context, group *Group) (string, error) {
 	// Check the path of the group being passed in.
+	var parentPath = path.Dir(group.Path)
 	// If there is only one group in the path, then this is a top-level group with no parentId
-	if group.Path == "/"+group.Name {
+	if parentPath == "/" {
 		return "", nil
 	}
 
-	groups, err := keycloakClient.ListGroupsWithName(ctx, group.RealmId, group.Name)
+	var parentGroup Group
+
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/group-by-path/%s", group.RealmId, parentPath), &parentGroup, nil)
 	if err != nil {
 		return "", err
 	}
 
-	var parentGroup Group
-	if parentGroupId, found := findParentGroup(*group, groups, parentGroup); found {
-		return parentGroupId, nil
-	}
-
-	// maybe panic here?  this should never happen
-	return "", fmt.Errorf("unable to determine parent ID for group with path %s", group.Path)
-}
-
-func findParentGroup(group Group, ingroups []*Group, parentGroup Group) (string, bool) {
-	for _, grp := range ingroups {
-		if grp.Id == group.Id {
-			return parentGroup.Id, true
-		}
-		if strings.HasPrefix(group.Path, grp.Path+"/") {
-
-			if parentGroupId, found := findParentGroup(group, grp.SubGroups, *grp); found {
-				return parentGroupId, found
-			}
-		}
-	}
-	return "", false
+	return parentGroup.Id, nil
 }
 
 func (keycloakClient *KeycloakClient) ValidateGroupMembers(usernames []interface{}) error {


### PR DESCRIPTION
Fixes #1223

Replaces the approach of searching by the parent group's name with Keycloak's native `group-by-path` API, as implemented here

https://github.com/keycloak/keycloak/blob/26.2.5/services/src/main/java/org/keycloak/services/resources/admin/RealmAdminResource.java#L1249-L1269

Under the hood, Keycloak actually does the same thing, though without the network overhead of printing every matching group on the realm. The Terraform provider was also using fuzzy-matching with was significantly impacting performance on Keycloak realms with a large number of groups with the same name in my case. 