### PR TITLE
expose EnableStandardTokenExchange  and allow refresh token in standard token exchange in keycloak_openid_client 

### DIFF
--- a/keycloak/openid_client.go
+++ b/keycloak/openid_client.go
@@ -61,29 +61,30 @@ type OpenidClient struct {
 }
 
 type OpenidClientAttributes struct {
-	PkceCodeChallengeMethod               string                           `json:"pkce.code.challenge.method"`
-	ExcludeSessionStateFromAuthResponse   types.KeycloakBoolQuoted         `json:"exclude.session.state.from.auth.response"`
-	ExcludeIssuerFromAuthResponse         types.KeycloakBoolQuoted         `json:"exclude.issuer.from.auth.response"`
-	AccessTokenLifespan                   string                           `json:"access.token.lifespan"`
-	LoginTheme                            string                           `json:"login_theme"`
-	ClientOfflineSessionIdleTimeout       string                           `json:"client.offline.session.idle.timeout,omitempty"`
-	DisplayOnConsentScreen                types.KeycloakBoolQuoted         `json:"display.on.consent.screen"`
-	ConsentScreenText                     string                           `json:"consent.screen.text"`
-	ClientOfflineSessionMaxLifespan       string                           `json:"client.offline.session.max.lifespan,omitempty"`
-	ClientSessionIdleTimeout              string                           `json:"client.session.idle.timeout,omitempty"`
-	ClientSessionMaxLifespan              string                           `json:"client.session.max.lifespan,omitempty"`
-	UseRefreshTokens                      types.KeycloakBoolQuoted         `json:"use.refresh.tokens"`
-	UseRefreshTokensClientCredentials     types.KeycloakBoolQuoted         `json:"client_credentials.use_refresh_token"`
-	BackchannelLogoutUrl                  string                           `json:"backchannel.logout.url"`
-	FrontchannelLogoutUrl                 string                           `json:"frontchannel.logout.url"`
-	BackchannelLogoutRevokeOfflineTokens  types.KeycloakBoolQuoted         `json:"backchannel.logout.revoke.offline.tokens"`
-	BackchannelLogoutSessionRequired      types.KeycloakBoolQuoted         `json:"backchannel.logout.session.required"`
-	ExtraConfig                           map[string]interface{}           `json:"-"`
-	Oauth2DeviceAuthorizationGrantEnabled types.KeycloakBoolQuoted         `json:"oauth2.device.authorization.grant.enabled"`
-	Oauth2DeviceCodeLifespan              string                           `json:"oauth2.device.code.lifespan,omitempty"`
-	Oauth2DevicePollingInterval           string                           `json:"oauth2.device.polling.interval,omitempty"`
-	PostLogoutRedirectUris                types.KeycloakSliceHashDelimited `json:"post.logout.redirect.uris,omitempty"`
-	StandardTokenExchangeEnabled          types.KeycloakBoolQuoted         `json:"standard.token.exchange.enabled,omitempty"`
+	PkceCodeChallengeMethod                  string                           `json:"pkce.code.challenge.method"`
+	ExcludeSessionStateFromAuthResponse      types.KeycloakBoolQuoted         `json:"exclude.session.state.from.auth.response"`
+	ExcludeIssuerFromAuthResponse            types.KeycloakBoolQuoted         `json:"exclude.issuer.from.auth.response"`
+	AccessTokenLifespan                      string                           `json:"access.token.lifespan"`
+	LoginTheme                               string                           `json:"login_theme"`
+	ClientOfflineSessionIdleTimeout          string                           `json:"client.offline.session.idle.timeout,omitempty"`
+	DisplayOnConsentScreen                   types.KeycloakBoolQuoted         `json:"display.on.consent.screen"`
+	ConsentScreenText                        string                           `json:"consent.screen.text"`
+	ClientOfflineSessionMaxLifespan          string                           `json:"client.offline.session.max.lifespan,omitempty"`
+	ClientSessionIdleTimeout                 string                           `json:"client.session.idle.timeout,omitempty"`
+	ClientSessionMaxLifespan                 string                           `json:"client.session.max.lifespan,omitempty"`
+	UseRefreshTokens                         types.KeycloakBoolQuoted         `json:"use.refresh.tokens"`
+	UseRefreshTokensClientCredentials        types.KeycloakBoolQuoted         `json:"client_credentials.use_refresh_token"`
+	BackchannelLogoutUrl                     string                           `json:"backchannel.logout.url"`
+	FrontchannelLogoutUrl                    string                           `json:"frontchannel.logout.url"`
+	BackchannelLogoutRevokeOfflineTokens     types.KeycloakBoolQuoted         `json:"backchannel.logout.revoke.offline.tokens"`
+	BackchannelLogoutSessionRequired         types.KeycloakBoolQuoted         `json:"backchannel.logout.session.required"`
+	ExtraConfig                              map[string]interface{}           `json:"-"`
+	Oauth2DeviceAuthorizationGrantEnabled    types.KeycloakBoolQuoted         `json:"oauth2.device.authorization.grant.enabled"`
+	Oauth2DeviceCodeLifespan                 string                           `json:"oauth2.device.code.lifespan,omitempty"`
+	Oauth2DevicePollingInterval              string                           `json:"oauth2.device.polling.interval,omitempty"`
+	PostLogoutRedirectUris                   types.KeycloakSliceHashDelimited `json:"post.logout.redirect.uris,omitempty"`
+	StandardTokenExchangeEnabled             types.KeycloakBoolQuoted         `json:"standard.token.exchange.enabled,omitempty"`
+	AllowRefreshTokenInStandardTokenExchange string                           `json:"standard.token.exchange.enableRefreshRequestedTokenType,omitempty"`
 }
 
 type OpenidAuthenticationFlowBindingOverrides struct {

--- a/provider/resource_keycloak_openid_client_test.go
+++ b/provider/resource_keycloak_openid_client_test.go
@@ -2,11 +2,12 @@ package provider
 
 import (
 	"fmt"
-	"github.com/keycloak/terraform-provider-keycloak/keycloak/types"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/keycloak/terraform-provider-keycloak/keycloak/types"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -792,6 +793,48 @@ func TestAccKeycloakOpenidClient_useRefreshTokens(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakOpenidClient_enableStandardTokenExchange(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOpenidClientDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenidClient_enableStandardTokenExchange(clientId, true),
+				Check:  testAccCheckKeycloakOpenidClientEnableStandardTokenExchange("keycloak_openid_client.client", true),
+			},
+			{
+				Config: testKeycloakOpenidClient_enableStandardTokenExchange(clientId, false),
+				Check:  testAccCheckKeycloakOpenidClientEnableStandardTokenExchange("keycloak_openid_client.client", false),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOpenidClient_allowRefreshTokenInStandardExchange(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckKeycloakOpenidClientDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenidClient_allowRefreshTokenInStandardExchange(clientId, "SAME_SESSION"),
+				Check:  testAccCheckKeycloakOpenidClientEnableStandardTokenExchange("keycloak_openid_client.client", true),
+			},
+			{
+				Config: testKeycloakOpenidClient_allowRefreshTokenInStandardExchange(clientId, ""),
+				Check:  testAccCheckKeycloakOpenidClientEnableStandardTokenExchange("keycloak_openid_client.client", false),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakOpenidClient_useRefreshTokensClientCredentials(t *testing.T) {
 	t.Parallel()
 	clientId := acctest.RandomWithPrefix("tf-acc")
@@ -1271,6 +1314,36 @@ func testAccCheckKeycloakOpenidClientUseRefreshTokens(resourceName string, useRe
 
 		if client.Attributes.UseRefreshTokens != types.KeycloakBoolQuoted(useRefreshTokens) {
 			return fmt.Errorf("expected openid client to have use refresh tokens set to %t, but got %v", useRefreshTokens, client.Attributes.UseRefreshTokens)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKeycloakOpenidClientEnableStandardTokenExchange(resourceName string, enableStandardTokenExchange bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := getOpenidClientFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if client.Attributes.StandardTokenExchangeEnabled != types.KeycloakBoolQuoted(enableStandardTokenExchange) {
+			return fmt.Errorf("expected openid client to have enable standard token exchange set to %t, but got %v", enableStandardTokenExchange, client.Attributes.StandardTokenExchangeEnabled)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKeycloakOpenidClientAllowRefreshTokenInStandardExchange(resourceName string, AllowRefreshTokenInStandardTokenExchange string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client, err := getOpenidClientFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if client.Attributes.AllowRefreshTokenInStandardTokenExchange != AllowRefreshTokenInStandardTokenExchange {
+			return fmt.Errorf("expected openid client to have enable standard token exchange set to %t, but got %v", AllowRefreshTokenInStandardTokenExchange, client.Attributes.AllowRefreshTokenInStandardTokenExchange)
 		}
 
 		return nil
@@ -1832,6 +1905,39 @@ resource "keycloak_openid_client" "client" {
 	use_refresh_tokens = %t
 }
 	`, testAccRealm.Realm, clientId, useRefreshTokens)
+}
+
+func testKeycloakOpenidClient_enableStandardTokenExchange(clientId string, enableStandardTokenExchange bool) string {
+
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "client" {
+	client_id   = "%s"
+	realm_id    = data.keycloak_realm.realm.id
+	access_type = "CONFIDENTIAL"
+	standard_token_exchange_enabled = %t
+}
+	`, testAccRealm.Realm, clientId, enableStandardTokenExchange)
+}
+
+func testKeycloakOpenidClient_allowRefreshTokenInStandardExchange(clientId string, allowRefreshTokenInStandardTokenExchange string) string {
+
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "client" {
+	client_id   = "%s"
+	realm_id    = data.keycloak_realm.realm.id
+	access_type = "CONFIDENTIAL"
+	standard_token_exchange_enabled = true
+	allow_refresh_token_in_standard_exchange = "%s"
+}
+	`, testAccRealm.Realm, clientId, allowRefreshTokenInStandardTokenExchange)
 }
 
 func testKeycloakOpenidClient_useRefreshTokensClientCredentials(clientId string, useRefreshTokensClientCredentials bool) string {


### PR DESCRIPTION
Signed-off-by: AvivGuiser <avivguiser@gmail.com>

the EnableStandardTokenExchange was added in a previous PR, i just saw that i could not pass it variable to the resource 
the allow refresh token in standard token exchange is a feature we just stated using in my org, but could not find a way to set via terraform 