### PR TITLE
chore: added documentation of standard_token_exchange_enabled and allow_refresh_token_in_standard_token_exchange

### DIFF
--- a/docs/resources/openid_client.md
+++ b/docs/resources/openid_client.md
@@ -159,6 +159,8 @@ is set to `true`.
 - `exclude_issuer_from_auth_response` - (Optional) When `true`, the parameter `iss` will not be included in OpenID Connect Authentication Response.
 - `use_refresh_tokens` - (Optional) If this is `true`, a refresh_token will be created and added to the token response. If this is `false` then no refresh_token will be generated.  Defaults to `true`.
 - `use_refresh_tokens_client_credentials` - (Optional) If this is `true`, a refresh_token will be created and added to the token response if the client_credentials grant is used and a user session will be created. If this is `false` then no refresh_token will be generated and the associated user session will be removed, in accordance with OAuth 2.0 RFC6749 Section 4.4.3. Defaults to `false`.
+- `standard_token_exchange_enabled` - (Optional) Enables support for Standard Token Exchange
+- `allow_refresh_token_in_standard_token_exchange` - (Optional) Defines whether to allow refresh token in Standard Token Exchange. Possible values are `NO` (default) and `SAME_SESSION`.
 - `oauth2_device_authorization_grant_enabled` - (Optional) Enables support for OAuth 2.0 Device Authorization Grant, which means that client is an application on device that has limited input capabilities or lack a suitable browser.
 - `oauth2_device_code_lifespan` - (Optional) The maximum amount of time a client has to finish the device code flow before it expires.
 - `oauth2_device_polling_interval` - (Optional) The minimum amount of time in seconds that the client should wait between polling requests to the token endpoint.


### PR DESCRIPTION
The documentation had been missing in the openid_client resource, hope you don't mind that I didn't open an issue beforehand.