### PR TITLE
feat: update go to 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,6 @@ require (
 	google.golang.org/protobuf v1.36.6 // indirect
 )
 
-go 1.23.0
+go 1.24.4
 
-toolchain go1.24.1
+toolchain go1.24.7


### PR DESCRIPTION
Go 1.23 has several CVEs. Updating to 1.24.4 mitigates these.

- [CVE-2025-22871](https://www.cve.org/CVERecord?id=CVE-2025-22871)
- [CVE-2025-22874](https://www.cve.org/CVERecord?id=CVE-2025-22874)
- [CVE-2025-4673](https://www.cve.org/CVERecord?id=CVE-2025-4673)
- [CVE-2025-0913](https://www.cve.org/CVERecord?id=CVE-2025-0913)

[Go 1.24 Release Notes](https://go.dev/doc/go1.24) for reference.