### PR TITLE
[Issue-1111] Move Realm Attributes to its own Resource

### DIFF
--- a/docs/resources/realm.md
+++ b/docs/resources/realm.md
@@ -24,9 +24,6 @@ resource "keycloak_realm" "realm" {
 
   ssl_required    = "external"
   password_policy = "upperCase(1) and length(8) and forceExpiredPasswordChange(365) and notUsername"
-  attributes      = {
-    mycustomAttribute = "myCustomValue"
-  }
 
   smtp_server {
     host = "smtp.example.com"
@@ -84,7 +81,7 @@ resource "keycloak_realm" "realm" {
 - `display_name_html` - (Optional) The display name for the realm that is rendered as HTML on the screen when logging in to the admin console.
 - `user_managed_access` - (Optional) When `true`, users are allowed to manage their own resources. Defaults to `false`.
 - `organizations_enabled` - (Optional) When `true`, organization support is enabled. Defaults to `false`.
-- `attributes` - (Optional) A map of custom attributes to add to the realm.
+- `attributes` - [Moved to its own resource see](./realm_attributes.md)
 - `internal_id` - (Optional) When specified, this will be used as the realm's internal ID within Keycloak. When not specified, the realm's internal ID will be set to the realm's name.
 
 ### Login Settings

--- a/docs/resources/realm_attributes.md
+++ b/docs/resources/realm_attributes.md
@@ -1,0 +1,24 @@
+---
+page_title: "keycloak_realm_attributes Resource"
+---
+
+# keycloak\_realm_attributes Resource
+
+Allows for creating and managing Realm attributes within Keycloak.
+
+## Example Usage
+
+```hcl
+resource "keycloak_realm" "realm_example" {
+  realm             = "realm-example"
+  enabled           = true
+}
+
+resource "keycloak_realm_attributes" "realm_attributes" {
+    realm_id = keycloak_realm.realm_example.id
+    attributes = {
+        baz = "bat"
+        qux = "quux"
+    }
+}
+```

--- a/example/main.tf
+++ b/example/main.tf
@@ -77,11 +77,6 @@ resource "keycloak_realm" "test" {
   ssl_required    = "external"
   password_policy = "upperCase(1) and length(8) and forceExpiredPasswordChange(365) and notUsername"
 
-  attributes = {
-    mycustomAttribute  = "myCustomValue"
-    userProfileEnabled = true
-  }
-
   web_authn_policy {
     relying_party_entity_name = "Example"
     relying_party_id          = "keycloak.example.com"
@@ -100,6 +95,15 @@ resource "keycloak_realm" "test" {
     ]
   }
 }
+
+resource "keycloak_realm_attributes" "test_attributes" {
+  realm_id = keycloak_realm.test.id
+
+  attributes = {
+    mycustomAttribute  = "myCustomValue"
+    userProfileEnabled = true
+  }
+} 
 
 resource "keycloak_realm_localization" "test_translation" {
   realm_id = keycloak_realm.test.id

--- a/keycloak/realm_attributes.go
+++ b/keycloak/realm_attributes.go
@@ -1,0 +1,27 @@
+package keycloak
+
+import (
+	"context"
+	"fmt"
+)
+
+type RealmAttributes struct {
+	RealmId    string                 `json:"-"`
+	Attributes map[string]interface{} `json:"attributes"`
+}
+
+func (keycloakClient *KeycloakClient) GetRealmAttributes(ctx context.Context, realmId string) (*RealmAttributes, error) {
+	realm, err := keycloakClient.GetRealm(ctx, realmId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RealmAttributes{
+		RealmId:    realmId,
+		Attributes: realm.Attributes,
+	}, nil
+}
+
+func (keycloakClient *KeycloakClient) UpdateRealmAttributes(ctx context.Context, realmId string, attributes *RealmAttributes) error {
+	return keycloakClient.put(ctx, fmt.Sprintf("/realms/%s", realmId), attributes)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -32,6 +32,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"keycloak_realm":                                             resourceKeycloakRealm(),
+			"keycloak_realm_attributes":                                  resourceKeycloakRealmAttributes(),
 			"keycloak_realm_events":                                      resourceKeycloakRealmEvents(),
 			"keycloak_realm_default_client_scopes":                       resourceKeycloakRealmDefaultClientScopes(),
 			"keycloak_realm_optional_client_scopes":                      resourceKeycloakRealmOptionalClientScopes(),

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -626,12 +626,6 @@ func resourceKeycloakRealm() *schema.Resource {
 				Computed:    true,
 			},
 
-			// misc attributes
-			"attributes": {
-				Type:     schema.TypeMap,
-				Optional: true,
-			},
-
 			// default default client scopes
 			"default_default_client_scopes": {
 				Type:     schema.TypeSet,

--- a/provider/resource_keycloak_realm_attributes.go
+++ b/provider/resource_keycloak_realm_attributes.go
@@ -1,0 +1,115 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakRealmAttributes() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKeycloakRealmAttributesCreate,
+		ReadContext:   resourceKeycloakRealmAttributesRead,
+		UpdateContext: resourceKeycloakRealmAttributesUpdate,
+		DeleteContext: resourceKeycloakRealmAttributesDelete,
+		Schema: map[string]*schema.Schema{
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"attributes": {
+				Type:        schema.TypeMap,
+				Required:    true,
+				Description: "A map of attributes for the realm",
+			},
+		},
+	}
+}
+func resourceKeycloakRealmAttributesCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+	realmId := data.Get("realm_id").(string)
+	attributes := mapFromDataToRealmAttributes(data)
+
+	err := keycloakClient.UpdateRealmAttributes(ctx, realmId, attributes)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(realmId)
+
+	return resourceKeycloakRealmAttributesRead(ctx, data, meta)
+}
+
+func resourceKeycloakRealmAttributesRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+	realmId := data.Get("realm_id").(string)
+	attributes, err := keycloakClient.GetRealmAttributes(ctx, realmId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if attributes == nil {
+		return nil
+	}
+
+	mapFromRealmAttributesToData(attributes, data)
+
+	return nil
+}
+
+func resourceKeycloakRealmAttributesUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+	realmId := data.Get("realm_id").(string)
+	attributes := mapFromDataToRealmAttributes(data)
+
+	err := keycloakClient.UpdateRealmAttributes(ctx, realmId, attributes)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceKeycloakRealmAttributesRead(ctx, data, meta)
+}
+
+func resourceKeycloakRealmAttributesDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+	realmId := data.Get("realm_id").(string)
+	attributes := &keycloak.RealmAttributes{
+		Attributes: map[string]interface{}{},
+	}
+
+	err := keycloakClient.UpdateRealmAttributes(ctx, realmId, attributes)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId("")
+
+	return nil
+}
+
+func mapFromDataToRealmAttributes(data *schema.ResourceData) *keycloak.RealmAttributes {
+	return &keycloak.RealmAttributes{
+		RealmId:    data.Get("realm_id").(string),
+		Attributes: data.Get("attributes").(map[string]interface{}),
+	}
+}
+
+func mapFromRealmAttributesToData(attributes *keycloak.RealmAttributes, data *schema.ResourceData) {
+	stickyRealmAttributes := []string{
+		"cibaAuthRequestedUserHint",
+		"cibaBackchannelTokenDeliveryMode",
+		"cibaExpiresIn",
+		"cibaInterval",
+		"oauth2DeviceCodeLifespan",
+		"oauth2DevicePollingInterval",
+		"parRequestUriLifespan",
+	}
+	for _, key := range stickyRealmAttributes {
+		delete(attributes.Attributes, key)
+	}
+	if err := data.Set("attributes", attributes.Attributes); err != nil {
+		panic(fmt.Sprintf("Failed to set attributes: %v", err))
+	}
+}

--- a/provider/resource_keycloak_realm_attributes_test.go
+++ b/provider/resource_keycloak_realm_attributes_test.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccKeycloakRealmAttributes(t *testing.T) {
+	realmName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviderFactories,
+		PreCheck:          func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakRealmAttributes_basic(realmName, "foo", "bar"),
+				Check:  testAccCheckKeycloakRealmAttributesExists(realmName),
+			},
+		},
+	})
+}
+
+func testKeycloakRealmAttributes_basic(realm string, name string, description string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm = "%s"
+
+
+resource "keycloak_realm_attributes" "attributes" {
+	realm_id = keycloak_realm.realm.id
+	attributes = {
+		name        = "%s"
+		description = "%s"
+	}
+}`, realm, name, description)
+}
+
+func testAccCheckKeycloakRealmAttributesExists(realm string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, err := keycloakClient.GetRealmAttributes(testCtx, realm)
+		if err != nil {
+			return fmt.Errorf("Realm attributes not found: %s", realm)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
this will help decouple the realms attributes and allow reuse in modules
 without relying on the entire realm configuration.