### PR TITLE
Add openid client authorization regex policy

### DIFF
--- a/docs/resources/openid_client_regex_policy.md
+++ b/docs/resources/openid_client_regex_policy.md
@@ -1,0 +1,69 @@
+---
+page_title: "keycloak_openid_client_regex_policy Resource"
+---
+
+# keycloak\_openid\_client\_regex\_policy Resource
+
+Allows you to manage Regex policies.
+
+Regex policies allow you to define conditions using regular expressions evaluated on attributes of either the current identity or a specific target claim.
+
+## Example Usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+resource "keycloak_openid_client" "test" {
+  client_id                = "client_id"
+  realm_id                 = keycloak_realm.realm.id
+  access_type              = "CONFIDENTIAL"
+  service_accounts_enabled = true
+  authorization {
+    policy_enforcement_mode = "ENFORCING"
+  }
+}
+
+resource "keycloak_openid_client_regex_policy" "test" {
+  resource_server_id = keycloak_openid_client.test.resource_server_id
+  realm_id           = keycloak_realm.realm.id
+  name               = "regex_policy"
+  decision_strategy  = "UNANIMOUS"
+  logic              = "POSITIVE"
+  target_claim       = "sample-claim"
+  pattern            = "^sample.+$"
+}
+```
+
+### Argument Reference
+
+The following arguments are supported:
+
+- `realm_id` - (Required) The realm this policy exists in.
+- `resource_server_id` - (Required) The ID of the resource server.
+- `name` - (Required) The name of the policy.
+- `decision_strategy` - (Required) The decision strategy, can be one of `UNANIMOUS`, `AFFIRMATIVE`, or `CONSENSUS`.
+- `target_claim` - (Required) The name of the target claim in the token.
+- `pattern` - (Required) The Regex pattern.
+- `target_context_attributes` - (Optional) `true` if policy should be evaluated on context attributes instead of identity attributes.
+- `logic` - (Optional) The logic, can be one of `POSITIVE` or `NEGATIVE`. Defaults to `POSITIVE`.
+- `type` - (Optional) The type of the policy. Defaults to `regex`.
+- `description` - (Optional) A description for the authorization policy.
+
+### Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+- `id` - Policy ID representing the Regex policy.
+
+## Import
+
+Regex policies can be imported using the format: `{{realmId}}/{{resourceServerId}}/{{policyId}}`.
+
+Example:
+
+```bash
+$ terraform import keycloak_openid_client_regex_policy.test my-realm/3bd4a686-1062-4b59-97b8-e4e3f10b99da/63b3cde8-987d-4cd9-9306-1955579281d9
+```

--- a/example/client_authorization_policys.tf
+++ b/example/client_authorization_policys.tf
@@ -196,3 +196,14 @@ resource "keycloak_openid_client_permissions" "my_permission" {
     keycloak_users_permissions.my_permission
   ]
 }
+
+resource "keycloak_openid_client_regex_policy" "test" {
+    resource_server_id = keycloak_openid_client.test.resource_server_id
+    realm_id           = keycloak_realm.test_authorization.id
+    name               = "client_regex_policy_test"
+    target_claim       = "sample-claim"
+    pattern            = "^sample.+$"
+    target_context_attributes = true
+    logic              = "POSITIVE"
+    decision_strategy  = "UNANIMOUS"
+  }

--- a/keycloak/openid_client_authorization_regex_policy.go
+++ b/keycloak/openid_client_authorization_regex_policy.go
@@ -1,0 +1,60 @@
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type OpenidClientAuthorizationRegexPolicy struct {
+	Id                      string `json:"id,omitempty"`
+	RealmId                 string `json:"-"`
+	ResourceServerId        string `json:"-"`
+	Name                    string `json:"name"`
+	DecisionStrategy        string `json:"decisionStrategy"`
+	Logic                   string `json:"logic"`
+	Type                    string `json:"type"`
+	Pattern                 string `json:"pattern"`
+	Description             string `json:"description"`
+	TargetClaim             string `json:"targetClaim"`
+	TargetContextAttributes bool   `json:"targetContextAttributes"`
+}
+
+func (keycloakClient *KeycloakClient) NewOpenidClientAuthorizationRegexPolicy(ctx context.Context, policy *OpenidClientAuthorizationRegexPolicy) error {
+	body, _, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/regex", policy.RealmId, policy.ResourceServerId), policy)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(body, &policy)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (keycloakClient *KeycloakClient) UpdateOpenidClientAuthorizationRegexPolicy(ctx context.Context, policy *OpenidClientAuthorizationRegexPolicy) error {
+	err := keycloakClient.put(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/regex/%s", policy.RealmId, policy.ResourceServerId, policy.Id), policy)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (keycloakClient *KeycloakClient) DeleteOpenidClientAuthorizationRegexPolicy(ctx context.Context, realmId, resourceServerId, policyId string) error {
+	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/regex/%s", realmId, resourceServerId, policyId), nil)
+}
+
+func (keycloakClient *KeycloakClient) GetOpenidClientAuthorizationRegexPolicy(ctx context.Context, realmId, resourceServerId, policyId string) (*OpenidClientAuthorizationRegexPolicy, error) {
+
+	policy := OpenidClientAuthorizationRegexPolicy{
+		Id:               policyId,
+		ResourceServerId: resourceServerId,
+		RealmId:          realmId,
+	}
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/regex/%s", realmId, resourceServerId, policyId), &policy, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &policy, nil
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -115,6 +115,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 			"keycloak_openid_client_time_policy":                         resourceKeycloakOpenidClientAuthorizationTimePolicy(),
 			"keycloak_openid_client_user_policy":                         resourceKeycloakOpenidClientAuthorizationUserPolicy(),
 			"keycloak_openid_client_client_policy":                       resourceKeycloakOpenidClientAuthorizationClientPolicy(),
+			"keycloak_openid_client_regex_policy":                        resourceKeycloakOpenidClientAuthorizationRegexPolicy(),
 			"keycloak_openid_client_authorization_client_scope_policy":   resourceKeycloakOpenidClientAuthorizationClientScopePolicy(),
 			"keycloak_openid_client_authorization_scope":                 resourceKeycloakOpenidClientAuthorizationScope(),
 			"keycloak_openid_client_authorization_permission":            resourceKeycloakOpenidClientAuthorizationPermission(),

--- a/provider/resource_keycloak_openid_client_authorization_regex_policy.go
+++ b/provider/resource_keycloak_openid_client_authorization_regex_policy.go
@@ -1,0 +1,150 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakOpenidClientAuthorizationRegexPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKeycloakOpenidClientAuthorizationRegexPolicyCreate,
+		ReadContext:   resourceKeycloakOpenidClientAuthorizationRegexPolicyRead,
+		DeleteContext: resourceKeycloakOpenidClientAuthorizationRegexPolicyDelete,
+		UpdateContext: resourceKeycloakOpenidClientAuthorizationRegexPolicyUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: genericResourcePolicyImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"resource_server_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"decision_strategy": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"logic": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(keycloakPolicyLogicTypes, false),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"target_claim": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"pattern": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"target_context_attributes": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func getOpenidClientAuthorizationRegexPolicyResourceFromData(data *schema.ResourceData) *keycloak.OpenidClientAuthorizationRegexPolicy {
+
+	resource := keycloak.OpenidClientAuthorizationRegexPolicy{
+		Id:                      data.Id(),
+		ResourceServerId:        data.Get("resource_server_id").(string),
+		RealmId:                 data.Get("realm_id").(string),
+		DecisionStrategy:        data.Get("decision_strategy").(string),
+		Logic:                   data.Get("logic").(string),
+		Name:                    data.Get("name").(string),
+		Type:                    "regex",
+		Pattern:                 data.Get("pattern").(string),
+		Description:             data.Get("description").(string),
+		TargetClaim:             data.Get("target_claim").(string),
+		TargetContextAttributes: data.Get("target_context_attributes").(bool),
+	}
+	return &resource
+}
+
+func setOpenidClientAuthorizationRegexPolicyResourceData(data *schema.ResourceData, policy *keycloak.OpenidClientAuthorizationRegexPolicy) {
+	data.SetId(policy.Id)
+
+	data.Set("resource_server_id", policy.ResourceServerId)
+	data.Set("realm_id", policy.RealmId)
+	data.Set("name", policy.Name)
+	data.Set("decision_strategy", policy.DecisionStrategy)
+	data.Set("logic", policy.Logic)
+	data.Set("description", policy.Description)
+	data.Set("pattern", policy.Pattern)
+	data.Set("target_claim", policy.TargetClaim)
+	data.Set("target_context_attributes", policy.TargetContextAttributes)
+}
+
+func resourceKeycloakOpenidClientAuthorizationRegexPolicyCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	resource := getOpenidClientAuthorizationRegexPolicyResourceFromData(data)
+
+	err := keycloakClient.NewOpenidClientAuthorizationRegexPolicy(ctx, resource)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	setOpenidClientAuthorizationRegexPolicyResourceData(data, resource)
+
+	return resourceKeycloakOpenidClientAuthorizationRegexPolicyRead(ctx, data, meta)
+}
+
+func resourceKeycloakOpenidClientAuthorizationRegexPolicyRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	resourceServerId := data.Get("resource_server_id").(string)
+	id := data.Id()
+
+	resource, err := keycloakClient.GetOpenidClientAuthorizationRegexPolicy(ctx, realmId, resourceServerId, id)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	setOpenidClientAuthorizationRegexPolicyResourceData(data, resource)
+
+	return nil
+}
+
+func resourceKeycloakOpenidClientAuthorizationRegexPolicyUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	resource := getOpenidClientAuthorizationRegexPolicyResourceFromData(data)
+
+	err := keycloakClient.UpdateOpenidClientAuthorizationRegexPolicy(ctx, resource)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	setOpenidClientAuthorizationRegexPolicyResourceData(data, resource)
+
+	return nil
+}
+
+func resourceKeycloakOpenidClientAuthorizationRegexPolicyDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	resourceServerId := data.Get("resource_server_id").(string)
+	id := data.Id()
+
+	return diag.FromErr(keycloakClient.DeleteOpenidClientAuthorizationRegexPolicy(ctx, realmId, resourceServerId, id))
+}

--- a/provider/resource_keycloak_openid_client_authorization_regex_policy_test.go
+++ b/provider/resource_keycloak_openid_client_authorization_regex_policy_test.go
@@ -1,0 +1,110 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func TestAccKeycloakOpenidClientAuthorizationRegexPolicy(t *testing.T) {
+	skipIfVersionIsLessThan(testCtx, t, keycloakClient, keycloak.Version_24)
+
+	clientId := acctest.RandomWithPrefix("tf-acc")
+	pattern := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testResourceKeycloakOpenidClientAuthorizationRegexPolicyDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceKeycloakOpenidClientAuthorizationRegexPolicy_basic(clientId, pattern, "sample-claim", true),
+				Check:  testResourceKeycloakOpenidClientAuthorizationRegexPolicyExists("keycloak_openid_client_regex_policy.test"),
+			},
+		},
+	})
+}
+
+func getResourceKeycloakOpenidClientAuthorizationRegexPolicyFromState(s *terraform.State, resourceName string) (*keycloak.OpenidClientAuthorizationRegexPolicy, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("resource not found: %s", resourceName)
+	}
+
+	realm := rs.Primary.Attributes["realm_id"]
+	resourceServerId := rs.Primary.Attributes["resource_server_id"]
+	policyId := rs.Primary.ID
+
+	policy, err := keycloakClient.GetOpenidClientAuthorizationRegexPolicy(testCtx, realm, resourceServerId, policyId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting openid client auth regex policy config with alias %s: %s", resourceServerId, err)
+	}
+
+	return policy, nil
+}
+
+func testResourceKeycloakOpenidClientAuthorizationRegexPolicyDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "keycloak_openid_client_regex_policy" {
+				continue
+			}
+
+			realm := rs.Primary.Attributes["realm_id"]
+			resourceServerId := rs.Primary.Attributes["resource_server_id"]
+			policyId := rs.Primary.ID
+
+			policy, _ := keycloakClient.GetOpenidClientAuthorizationRegexPolicy(testCtx, realm, resourceServerId, policyId)
+			if policy != nil {
+				return fmt.Errorf("policy config with id %s still exists", policyId)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testResourceKeycloakOpenidClientAuthorizationRegexPolicyExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, err := getResourceKeycloakOpenidClientAuthorizationRegexPolicyFromState(s, resourceName)
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testResourceKeycloakOpenidClientAuthorizationRegexPolicy_basic(clientId, pattern, targetClaim string, targetContextAttributes bool) string {
+	return fmt.Sprintf(`
+	data "keycloak_realm" "realm" {
+		realm = "%s"
+	}
+
+	resource keycloak_openid_client test {
+		client_id                = "%s"
+		realm_id                 = data.keycloak_realm.realm.id
+		access_type              = "CONFIDENTIAL"
+		service_accounts_enabled = true
+		authorization {
+			policy_enforcement_mode = "ENFORCING"
+		}
+	}
+
+	resource keycloak_openid_client_regex_policy test {
+		resource_server_id = "${keycloak_openid_client.test.resource_server_id}"
+		realm_id = data.keycloak_realm.realm.id
+		name = "client_regex_policy_test"
+		pattern = "%s"
+		logic = "POSITIVE"
+		decision_strategy = "UNANIMOUS"
+        target_claim = "%s"
+        target_context_attributes = %t
+	}
+	`, testAccRealm.Realm, clientId, pattern, targetClaim, targetContextAttributes)
+}


### PR DESCRIPTION
### Summary
Add a new resource to create and manage regex policies in Keycloak.

### Usage
```hcl
resource "keycloak_openid_client_regex_policy" "example" {
  realm_id  = keycloak_realm.example.id
  client_id = keycloak_openid_client.example.id
  name      = "example-regex-policy"

  target_claim = "sample-claim"
  pattern      = ".*"

  target_context_attributes = "example_attribute"

  logic             = "POSITIVE"
  decision_strategy = "UNANIMOUS"
}
```

### Changes

- Add keycloak_openid_client_regex_policy resource
- Add resource documentation page for keycloak_openid_client_regex_policy 