### PR TITLE
Fix/handle missing systeminfo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -153,6 +153,18 @@ provider "keycloak" {
 }
 ```
 
+### Example Usage (with manual server version)
+```hcl
+provider "keycloak" {
+	client_id      = "terraform"
+	client_secret  = "884e0f95-0f42-4a63-9b1f-94274655669e"
+	url            = "http://localhost:8080"
+	server_version = "26.0.0"
+}
+```
+
+This is useful when the Keycloak server doesn't expose version information through the `/serverinfo` endpoint, such as when using Red Hat SSO with version information disabled for security reasons.
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -176,4 +188,6 @@ The following arguments are supported:
 - `tls_client_certificate` - (Optional) The TLS client certificate in PEM format when the keycloak server is configured with TLS mutual authentication.
 - `tls_client_private_key` - (Optional) The TLS client pkcs1 private key in PEM format when the keycloak server is configured with TLS mutual authentication.
 - `base_path` - (Optional) The base path used for accessing the Keycloak REST API.  Defaults to the environment variable `KEYCLOAK_BASE_PATH`, or an empty string if the environment variable is not specified. Note that users of the legacy distribution of Keycloak will need to set this attribute to `/auth`.
+- `red_hat_sso` - (Optional) When true, the provider will treat the Keycloak instance as a Red Hat SSO server, specifically when parsing the version returned from the /serverinfo API endpoint. Defaults to `false`.
+- `server_version` - (Optional) Manually specify the Keycloak server version. When set, the provider will skip fetching the version from the server's /serverinfo endpoint. This is useful when the server doesn't expose version information (e.g., Red Hat SSO with disabled version info). Defaults to the environment variable `KEYCLOAK_SERVER_VERSION`. If the server version cannot be determined from the /serverinfo endpoint and this parameter is not set, an error will be returned.
 - `additional_headers` - (Optional) A map of custom HTTP headers to add to each request to the Keycloak API.

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -29,20 +29,20 @@ import (
 )
 
 type KeycloakClient struct {
-	baseUrl              string
-	authUrl              string
-	realm                string
-	clientCredentials    *ClientCredentials
-	httpClient           *http.Client
-	initialLogin         bool
-	userAgent            string
-	version              *version.Version
-	additionalHeaders    map[string]string
-	debug                bool
-	redHatSSO            bool
-	accessTokenProvided  bool
+	baseUrl               string
+	authUrl               string
+	realm                 string
+	clientCredentials     *ClientCredentials
+	httpClient            *http.Client
+	initialLogin          bool
+	userAgent             string
+	version               *version.Version
+	additionalHeaders     map[string]string
+	debug                 bool
+	redHatSSO             bool
+	accessTokenProvided   bool
 	providedServerVersion string
-	Mutex                *mutex.KeyValue
+	Mutex                 *mutex.KeyValue
 }
 
 type ClientCredentials struct {
@@ -112,18 +112,18 @@ func NewKeycloakClient(ctx context.Context, url, basePath, adminUrl, clientId, c
 	}
 
 	keycloakClient := KeycloakClient{
-		baseUrl:              baseUrl,
-		authUrl:              authUrl,
-		clientCredentials:    clientCredentials,
-		httpClient:           httpClient,
-		initialLogin:         initialLogin,
-		realm:                realm,
-		userAgent:            userAgent,
-		redHatSSO:            redHatSSO,
+		baseUrl:               baseUrl,
+		authUrl:               authUrl,
+		clientCredentials:     clientCredentials,
+		httpClient:            httpClient,
+		initialLogin:          initialLogin,
+		realm:                 realm,
+		userAgent:             userAgent,
+		redHatSSO:             redHatSSO,
 		providedServerVersion: serverVersion,
-		additionalHeaders:    additionalHeaders,
-		accessTokenProvided:  accessToken != "",
-		Mutex:                mutex.New(),
+		additionalHeaders:     additionalHeaders,
+		accessTokenProvided:   accessToken != "",
+		Mutex:                 mutex.New(),
 	}
 
 	if accessToken == "" && keycloakClient.initialLogin {

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -29,19 +29,20 @@ import (
 )
 
 type KeycloakClient struct {
-	baseUrl             string
-	authUrl             string
-	realm               string
-	clientCredentials   *ClientCredentials
-	httpClient          *http.Client
-	initialLogin        bool
-	userAgent           string
-	version             *version.Version
-	additionalHeaders   map[string]string
-	debug               bool
-	redHatSSO           bool
-	accessTokenProvided bool
-	Mutex               *mutex.KeyValue
+	baseUrl              string
+	authUrl              string
+	realm                string
+	clientCredentials    *ClientCredentials
+	httpClient           *http.Client
+	initialLogin         bool
+	userAgent            string
+	version              *version.Version
+	additionalHeaders    map[string]string
+	debug                bool
+	redHatSSO            bool
+	accessTokenProvided  bool
+	providedServerVersion string
+	Mutex                *mutex.KeyValue
 }
 
 type ClientCredentials struct {
@@ -72,7 +73,7 @@ var redHatSSO7VersionMap = map[int]string{
 	4: "9.0.17",
 }
 
-func NewKeycloakClient(ctx context.Context, url, basePath, adminUrl, clientId, clientSecret, realm, username, password, accessToken, jwtSigningAlg, jwtSigningKey, jwtToken, jwtTokenFile string, initialLogin bool, clientTimeout int, caCert string, tlsInsecureSkipVerify bool, tlsClientCert string, tlsClientPrivateKey string, userAgent string, redHatSSO bool, additionalHeaders map[string]string) (*KeycloakClient, error) {
+func NewKeycloakClient(ctx context.Context, url, basePath, adminUrl, clientId, clientSecret, realm, username, password, accessToken, jwtSigningAlg, jwtSigningKey, jwtToken, jwtTokenFile string, initialLogin bool, clientTimeout int, caCert string, tlsInsecureSkipVerify bool, tlsClientCert string, tlsClientPrivateKey string, userAgent string, redHatSSO bool, serverVersion string, additionalHeaders map[string]string) (*KeycloakClient, error) {
 	clientCredentials := &ClientCredentials{
 		ClientId:      clientId,
 		ClientSecret:  clientSecret,
@@ -111,17 +112,18 @@ func NewKeycloakClient(ctx context.Context, url, basePath, adminUrl, clientId, c
 	}
 
 	keycloakClient := KeycloakClient{
-		baseUrl:             baseUrl,
-		authUrl:             authUrl,
-		clientCredentials:   clientCredentials,
-		httpClient:          httpClient,
-		initialLogin:        initialLogin,
-		realm:               realm,
-		userAgent:           userAgent,
-		redHatSSO:           redHatSSO,
-		additionalHeaders:   additionalHeaders,
-		accessTokenProvided: accessToken != "",
-		Mutex:               mutex.New(),
+		baseUrl:              baseUrl,
+		authUrl:              authUrl,
+		clientCredentials:    clientCredentials,
+		httpClient:           httpClient,
+		initialLogin:         initialLogin,
+		realm:                realm,
+		userAgent:            userAgent,
+		redHatSSO:            redHatSSO,
+		providedServerVersion: serverVersion,
+		additionalHeaders:    additionalHeaders,
+		accessTokenProvided:  accessToken != "",
+		Mutex:                mutex.New(),
 	}
 
 	if accessToken == "" && keycloakClient.initialLogin {
@@ -197,14 +199,30 @@ func (keycloakClient *KeycloakClient) login(ctx context.Context) error {
 		})
 	}
 
-	info, err := keycloakClient.GetServerInfo(ctx)
-	if err != nil {
-		return err
+	var serverVersion string
+
+	// Use provided server version if available, otherwise fetch from server
+	if keycloakClient.providedServerVersion != "" {
+		tflog.Info(ctx, "Using provided server version", map[string]interface{}{
+			"version": keycloakClient.providedServerVersion,
+		})
+		serverVersion = keycloakClient.providedServerVersion
+	} else {
+		info, err := keycloakClient.GetServerInfo(ctx)
+		if err != nil {
+			return err
+		}
+
+		serverVersion = info.SystemInfo.ServerVersion
+
+		// Handle missing SystemInfo.ServerVersion (e.g., RHSSO with disabled version info)
+		if serverVersion == "" {
+			return fmt.Errorf("server version not available from systemInfo and server_version not configured. Please set the server_version provider parameter or KEYCLOAK_SERVER_VERSION environment variable")
+		}
 	}
 
-	serverVersion := info.SystemInfo.ServerVersion
 	if strings.Contains(serverVersion, ".GA") {
-		serverVersion = strings.ReplaceAll(info.SystemInfo.ServerVersion, ".GA", "")
+		serverVersion = strings.ReplaceAll(serverVersion, ".GA", "")
 	} else {
 		regex, err := regexp.Compile(`\.redhat-\w+`)
 

--- a/keycloak/keycloak_client_test.go
+++ b/keycloak/keycloak_client_test.go
@@ -23,7 +23,7 @@ func TestAccKeycloakClientConnect(t *testing.T) {
 
 	clientTimeout := checkClientTimeout(t)
 
-	keycloakClient, err := NewKeycloakClient(ctx, os.Getenv("KEYCLOAK_URL"), "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), true, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, map[string]string{
+	keycloakClient, err := NewKeycloakClient(ctx, os.Getenv("KEYCLOAK_URL"), "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), true, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, "", map[string]string{
 		"foo": "bar",
 	})
 
@@ -42,7 +42,7 @@ func TestAccKeycloakClientConnectAccessTokenAuth(t *testing.T) {
 
 	clientTimeout := checkClientTimeout(t)
 
-	keycloakClient, err := NewKeycloakClient(ctx, os.Getenv("KEYCLOAK_URL"), "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), true, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, map[string]string{
+	keycloakClient, err := NewKeycloakClient(ctx, os.Getenv("KEYCLOAK_URL"), "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), true, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, "", map[string]string{
 		"foo": "bar",
 	})
 	keycloakClientChecks(t, err, keycloakClient, ctx)
@@ -67,7 +67,7 @@ func TestAccKeycloakClientConnectHttpsMtlsAuth(t *testing.T) {
 			t.Fatalf("KEYCLOAK_URL_HTTP must also be set to https when using https")
 		}
 	}
-	keycloakClient, err := NewKeycloakClient(ctx, keycloakHttpUrl, "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, "", true, "", "", "", false, map[string]string{})
+	keycloakClient, err := NewKeycloakClient(ctx, keycloakHttpUrl, "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, "", true, "", "", "", false, "", map[string]string{})
 
 	_, err = keycloakClient.Version(ctx)
 	if err != nil {
@@ -86,7 +86,7 @@ func TestAccKeycloakClientConnectHttpsMtlsAuth(t *testing.T) {
 	}
 
 	// then try again to connect with Keycloak but this time via https with mtls client auth
-	mtlsKeycloakClient, err := NewKeycloakClient(ctx, keycloakUrl, "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), true, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, map[string]string{})
+	mtlsKeycloakClient, err := NewKeycloakClient(ctx, keycloakUrl, "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), true, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, "", map[string]string{})
 	keycloakClientChecks(t, err, mtlsKeycloakClient, ctx)
 }
 
@@ -107,7 +107,7 @@ func TestAccKeycloakApiClientRefresh(t *testing.T) {
 
 	clientTimeout := checkClientTimeout(t)
 
-	keycloakClient, err := NewKeycloakClient(ctx, os.Getenv("KEYCLOAK_URL"), "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), false, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, map[string]string{
+	keycloakClient, err := NewKeycloakClient(ctx, os.Getenv("KEYCLOAK_URL"), "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), false, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, "", map[string]string{
 		"foo": "bar",
 	})
 	if err != nil {
@@ -191,4 +191,76 @@ func keycloakClientChecks(t *testing.T, err error, keycloakClient *KeycloakClien
 	if version == nil {
 		t.Fatalf("%s", "Server Version not found")
 	}
+}
+
+func TestAccKeycloakClientConnectWithProvidedServerVersion(t *testing.T) {
+	ctx := context.Background()
+
+	helper.CheckRequiredEnvironmentVariables(t)
+
+	clientTimeout := checkClientTimeout(t)
+
+	// Test with a provided server version
+	providedVersion := "26.0.0"
+
+	keycloakClient, err := NewKeycloakClient(ctx, os.Getenv("KEYCLOAK_URL"), "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), true, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, providedVersion, map[string]string{
+		"foo": "bar",
+	})
+
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	// Verify that the provided version is used
+	if keycloakClient.providedServerVersion != providedVersion {
+		t.Fatalf("expected providedServerVersion to be %s, got %s", providedVersion, keycloakClient.providedServerVersion)
+	}
+
+	version, err := keycloakClient.Version(ctx)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	if version.String() != providedVersion {
+		t.Fatalf("expected version to be %s, got %s", providedVersion, version.String())
+	}
+}
+
+func TestAccKeycloakClientSkipGetServerInfoWhenVersionProvided(t *testing.T) {
+	ctx := context.Background()
+
+	helper.CheckRequiredEnvironmentVariables(t)
+
+	clientTimeout := checkClientTimeout(t)
+
+	// Test with a provided server version
+	providedVersion := "26.0.0"
+
+	// Create client with provided version and initialLogin=false to avoid calling GetServerInfo
+	keycloakClient, err := NewKeycloakClient(ctx, os.Getenv("KEYCLOAK_URL"), "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), false, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), true, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, providedVersion, map[string]string{})
+
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	// Manually trigger login which would normally call GetServerInfo
+	err = keycloakClient.login(ctx)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	// Verify that the version was set from the provided value
+	version, err := keycloakClient.Version(ctx)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	if version.String() != providedVersion {
+		t.Fatalf("expected version to be %s, got %s", providedVersion, version.String())
+	}
+
+	// Note: In a real integration test environment, we could set up a mock server
+	// and verify that GetServerInfo endpoint was not called. For acceptance tests
+	// against a real Keycloak instance, we verify the behavior by confirming the
+	// version is set correctly without errors, which proves the code path worked.
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -245,6 +245,12 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 				Description: "When true, the provider will treat the Keycloak instance as a Red Hat SSO server, specifically when parsing the version returned from the /serverinfo API endpoint.",
 				Default:     false,
 			},
+			"server_version": {
+				Optional:    true,
+				Type:        schema.TypeString,
+				Description: "Manually specify the Keycloak server version. When set, the provider will skip fetching the version from the server. Useful when the server doesn't expose version information.",
+				DefaultFunc: schema.EnvDefaultFunc("KEYCLOAK_SERVER_VERSION", ""),
+			},
 			"base_path": {
 				Optional:    true,
 				Type:        schema.TypeString,
@@ -285,6 +291,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 		tlsClientPrivateKey := data.Get("tls_client_private_key").(string)
 		rootCaCertificate := data.Get("root_ca_certificate").(string)
 		redHatSSO := data.Get("red_hat_sso").(bool)
+		serverVersion := data.Get("server_version").(string)
 		additionalHeaders := make(map[string]string)
 		for k, v := range data.Get("additional_headers").(map[string]interface{}) {
 			additionalHeaders[k] = v.(string)
@@ -293,7 +300,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 		var diags diag.Diagnostics
 
 		userAgent := fmt.Sprintf("HashiCorp Terraform/%s (+https://www.terraform.io) Terraform Plugin SDK/%s", provider.TerraformVersion, meta.SDKVersionString())
-		keycloakClient, err := keycloak.NewKeycloakClient(ctx, url, basePath, adminUrl, clientId, clientSecret, realm, username, password, accessToken, jwtSigningAlg, jwtSigningKey, jwtToken, jwtTokenFile, initialLogin, clientTimeout, rootCaCertificate, tlsInsecureSkipVerify, tlsClientCertificate, tlsClientPrivateKey, userAgent, redHatSSO, additionalHeaders)
+		keycloakClient, err := keycloak.NewKeycloakClient(ctx, url, basePath, adminUrl, clientId, clientSecret, realm, username, password, accessToken, jwtSigningAlg, jwtSigningKey, jwtToken, jwtTokenFile, initialLogin, clientTimeout, rootCaCertificate, tlsInsecureSkipVerify, tlsClientCertificate, tlsClientPrivateKey, userAgent, redHatSSO, serverVersion, additionalHeaders)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,

--- a/provider/provider_test.go
+++ b/provider/provider_test.go
@@ -34,7 +34,7 @@ func init() {
 	helper.UpdateEnvFromTestEnvIfPresent()
 
 	initialLogin := os.Getenv("KEYCLOAK_ACCESS_TOKEN") == ""
-	keycloakClient, err = keycloak.NewKeycloakClient(testCtx, os.Getenv("KEYCLOAK_URL"), "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), "", "", os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), "", initialLogin, 120, os.Getenv("KEYCLOAK_TLS_CA_CERT"), false, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), userAgent, false, map[string]string{
+	keycloakClient, err = keycloak.NewKeycloakClient(testCtx, os.Getenv("KEYCLOAK_URL"), "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), "", "", os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), "", initialLogin, 120, os.Getenv("KEYCLOAK_TLS_CA_CERT"), false, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), userAgent, false, "", map[string]string{
 		"foo": "bar",
 	})
 	if err != nil {


### PR DESCRIPTION
This is useful when the Keycloak server doesn't expose version information through the `/serverinfo` endpoint, such as when using Red Hat SSO with version information disabled for security reasons.

```hcl
provider "keycloak" {
	client_id      = "terraform"
	client_secret  = "884e0f95-0f42-4a63-9b1f-94274655669e"
	url            = "http://localhost:8080"
	server_version = "26.0.0"
}
```

It fixes:

```
Planning failed. Terraform encountered an error while generating this plan.
╷
│ Error: error initializing keycloak provider
│ 
│   with provider["registry.terraform.io/keycloak/keycloak"],
│   on 00-providers.tf line 30, in provider "keycloak":
│   30: provider "keycloak" {
│ 
│ failed to perform initial login to Keycloak: Malformed version: 
╵
```