### PR TITLE
feat(realm): passwordless passkeys

### DIFF
--- a/docs/resources/realm.md
+++ b/docs/resources/realm.md
@@ -258,6 +258,7 @@ Each of these attributes are blocks with the following attributes:
 - `avoid_same_authenticator_register` - (Optional) When `true`, Keycloak will avoid registering the authenticator for WebAuthn if it has already been registered. Defaults to `false`.
 - `acceptable_aaguids` - (Optional) A set of AAGUIDs for which an authenticator can be registered.
 - `extra_origins` - (Optional) A set of extra origins for non-web applications.
+- `passwordless_passkeys_enabled` - (Optional) When `true`, Keycloak will enable passwordless passkey support. Defaults to `false`.
 
 ## Default Client Scopes
 

--- a/keycloak/realm.go
+++ b/keycloak/realm.go
@@ -145,6 +145,7 @@ type Realm struct {
 	WebAuthnPolicyPasswordlessRpId                            string   `json:"webAuthnPolicyPasswordlessRpId"`
 	WebAuthnPolicyPasswordlessSignatureAlgorithms             []string `json:"webAuthnPolicyPasswordlessSignatureAlgorithms"`
 	WebAuthnPolicyPasswordlessUserVerificationRequirement     string   `json:"webAuthnPolicyPasswordlessUserVerificationRequirement"`
+	WebAuthnPolicyPasswordlessPasskeysEnabled                 bool     `json:"webAuthnPolicyPasswordlessPasskeysEnabled"`
 
 	// Roles
 	DefaultRole *Role `json:"defaultRole,omitempty"`

--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -96,6 +96,10 @@ func dataSourceKeycloakRealm() *schema.Resource {
 			Description: "Either required, preferred or discouraged",
 			Computed:    true,
 		},
+		"passwordless_passkeys_enabled": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
 	}
 	return &schema.Resource{
 		ReadContext: dataSourceKeycloakRealmRead,

--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -96,11 +96,17 @@ func dataSourceKeycloakRealm() *schema.Resource {
 			Description: "Either required, preferred or discouraged",
 			Computed:    true,
 		},
-		"passwordless_passkeys_enabled": {
-			Type:     schema.TypeBool,
-			Computed: true,
-		},
 	}
+
+	webAuthnPasswordlessSchema := make(map[string]*schema.Schema)
+	for k, v := range webAuthnSchema {
+		webAuthnPasswordlessSchema[k] = v
+	}
+	webAuthnPasswordlessSchema["passwordless_passkeys_enabled"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Computed: true,
+	}
+
 	return &schema.Resource{
 		ReadContext: dataSourceKeycloakRealmRead,
 		Schema: map[string]*schema.Schema{
@@ -582,7 +588,7 @@ func dataSourceKeycloakRealm() *schema.Resource {
 				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
-					Schema: webAuthnSchema,
+					Schema: webAuthnPasswordlessSchema,
 				},
 			},
 		},

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -1253,6 +1253,10 @@ func getRealmFromData(data *schema.ResourceData, keycloakVersion *version.Versio
 		if webAuthnPolicyPasswordlessUserVerificationRequirement, ok := webAuthnPasswordlessPolicy["user_verification_requirement"]; ok {
 			realm.WebAuthnPolicyPasswordlessUserVerificationRequirement = webAuthnPolicyPasswordlessUserVerificationRequirement.(string)
 		}
+
+		if webAuthnPolicyPasswordlessPasskeysEnabled, ok := webAuthnPasswordlessPolicy["passwordless_passkeys_enabled"]; ok {
+			realm.WebAuthnPolicyPasswordlessPasskeysEnabled = webAuthnPolicyPasswordlessPasskeysEnabled.(bool)
+		}
 	}
 
 	return realm, nil
@@ -1456,6 +1460,7 @@ func setRealmData(data *schema.ResourceData, realm *keycloak.Realm, keycloakVers
 	webAuthnPasswordlessPolicy["relying_party_id"] = realm.WebAuthnPolicyPasswordlessRpId
 	webAuthnPasswordlessPolicy["signature_algorithms"] = realm.WebAuthnPolicyPasswordlessSignatureAlgorithms
 	webAuthnPasswordlessPolicy["user_verification_requirement"] = realm.WebAuthnPolicyPasswordlessUserVerificationRequirement
+	webAuthnPasswordlessPolicy["passwordless_passkeys_enabled"] = realm.WebAuthnPolicyPasswordlessPasskeysEnabled
 	data.Set("web_authn_passwordless_policy", []interface{}{webAuthnPasswordlessPolicy})
 
 	attributes := map[string]interface{}{}

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -150,6 +150,17 @@ func resourceKeycloakRealm() *schema.Resource {
 			ValidateFunc: validation.StringInSlice([]string{"not specified", "required", "preferred", "discouraged"}, false),
 		},
 	}
+
+	webAuthnPasswordlessSchema := make(map[string]*schema.Schema)
+	for k, v := range webAuthnSchema {
+		webAuthnPasswordlessSchema[k] = v
+	}
+	webAuthnPasswordlessSchema["passwordless_passkeys_enabled"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	}
+
 	return &schema.Resource{
 		CreateContext: resourceKeycloakRealmCreate,
 		ReadContext:   resourceKeycloakRealmRead,
@@ -733,7 +744,7 @@ func resourceKeycloakRealm() *schema.Resource {
 				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
-					Schema: webAuthnSchema,
+					Schema: webAuthnPasswordlessSchema,
 				},
 			},
 		},

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -1041,6 +1041,7 @@ func TestAccKeycloakRealm_webauthn(t *testing.T) {
 	userVerificationRequirement := randomStringInSlice([]string{"not specified", "required", "preferred", "discouraged"})
 	signatureAlgorithms := randomStringSliceSubset([]string{"ES256", "ES384", "ES512", "RS256", "ES384", "ES512"})
 	avoidSameAuthenticatorRegister := randomBool()
+	passwordlessPasskeysEnabled := randomBool()
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviderFactories,
@@ -1052,7 +1053,7 @@ func TestAccKeycloakRealm_webauthn(t *testing.T) {
 				Check:  testAccCheckKeycloakRealmExists("keycloak_realm.realm"),
 			},
 			{
-				Config: testKeycloakRealm_webauthn_passwordless_policy(realmName, realmDisplayName, realmDisplayNameHtml, rpName, rpId, attestationConveyancePreference, authenticatorAttachment, requireResidentKey, userVerificationRequirement, signatureAlgorithms, avoidSameAuthenticatorRegister),
+				Config: testKeycloakRealm_webauthn_passwordless_policy(realmName, realmDisplayName, realmDisplayNameHtml, rpName, rpId, attestationConveyancePreference, authenticatorAttachment, requireResidentKey, userVerificationRequirement, signatureAlgorithms, avoidSameAuthenticatorRegister, passwordlessPasskeysEnabled),
 				Check:  testAccCheckKeycloakRealmExists("keycloak_realm.realm"),
 			},
 			{
@@ -1854,6 +1855,30 @@ resource "keycloak_realm" "realm" {
 	}
 }
 	`, realm, realmDisplayName, realmDisplayNameHtml, rpName, rpId, arrayOfStringsForTerraformResource(signatureAlgorithms), attestationConveyancePreference, authenticatorAttachment, avoidSameAuthenticatorRegister, requireResidentKey, userVerificationRequirement)
+}
+
+func testKeycloakRealm_webauthn_passwordless_policy(realm, realmDisplayName, realmDisplayNameHtml, rpName, rpId, attestationConveyancePreference, authenticatorAttachment, requireResidentKey, userVerificationRequirement string, signatureAlgorithms []string, avoidSameAuthenticatorRegister bool, passwordlessPasskeysEnabled bool) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm        		= "%s"
+	enabled     	 	= true
+	display_name 		= "%s"
+	display_name_html 	= "%s"
+
+	web_authn_passwordless_policy {
+		relying_party_entity_name         = "%s"
+		relying_party_id                  = "%s"
+		signature_algorithms              = %s
+
+		attestation_conveyance_preference = "%s"
+		authenticator_attachment          = "%s"
+		avoid_same_authenticator_register = %t
+		require_resident_key              = "%s"
+		user_verification_requirement     = "%s"
+		passwordless_passkeys_enabled     = %t
+	}
+}
+	`, realm, realmDisplayName, realmDisplayNameHtml, rpName, rpId, arrayOfStringsForTerraformResource(signatureAlgorithms), attestationConveyancePreference, authenticatorAttachment, avoidSameAuthenticatorRegister, requireResidentKey, userVerificationRequirement, passwordlessPasskeysEnabled)
 }
 
 func testKeycloakRealm_basicInternalId(realm, internalId string) string {

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -1834,29 +1834,6 @@ resource "keycloak_realm" "realm" {
 	`, realm, realmDisplayName, realmDisplayNameHtml, rpName, rpId, arrayOfStringsForTerraformResource(signatureAlgorithms), attestationConveyancePreference, authenticatorAttachment, avoidSameAuthenticatorRegister, requireResidentKey, userVerificationRequirement)
 }
 
-func testKeycloakRealm_webauthn_passwordless_policy(realm, realmDisplayName, realmDisplayNameHtml, rpName, rpId, attestationConveyancePreference, authenticatorAttachment, requireResidentKey, userVerificationRequirement string, signatureAlgorithms []string, avoidSameAuthenticatorRegister bool) string {
-	return fmt.Sprintf(`
-resource "keycloak_realm" "realm" {
-	realm        		= "%s"
-	enabled     	 	= true
-	display_name 		= "%s"
-	display_name_html 	= "%s"
-
-	web_authn_passwordless_policy {
-		relying_party_entity_name         = "%s"
-		relying_party_id                  = "%s"
-		signature_algorithms              = %s
-
-		attestation_conveyance_preference = "%s"
-		authenticator_attachment          = "%s"
-		avoid_same_authenticator_register = %t
-		require_resident_key              = "%s"
-		user_verification_requirement     = "%s"
-	}
-}
-	`, realm, realmDisplayName, realmDisplayNameHtml, rpName, rpId, arrayOfStringsForTerraformResource(signatureAlgorithms), attestationConveyancePreference, authenticatorAttachment, avoidSameAuthenticatorRegister, requireResidentKey, userVerificationRequirement)
-}
-
 func testKeycloakRealm_webauthn_passwordless_policy(realm, realmDisplayName, realmDisplayNameHtml, rpName, rpId, attestationConveyancePreference, authenticatorAttachment, requireResidentKey, userVerificationRequirement string, signatureAlgorithms []string, avoidSameAuthenticatorRegister bool, passwordlessPasskeysEnabled bool) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {


### PR DESCRIPTION
This pr adds support for the passwordless_passkeys_enabled parameter
in the WebAuthn passwordless policy configuration. This allows users to
enable passwordless passkey support in Keycloak realms.

Changes include:
- Added WebAuthnPolicyPasswordlessPasskeysEnabled field to Realm struct
- Added passwordless_passkeys_enabled to realm resource schema
- Added passwordless_passkeys_enabled to realm data source schema
- Updated documentation for the new parameter
- Added test coverage for the new parameter

Closes #1354

