### PR TITLE
Add keycloak_openid_client_authorization_permission_scope resource

### DIFF
--- a/keycloak/openid_client_authorization_permission_scope.go
+++ b/keycloak/openid_client_authorization_permission_scope.go
@@ -1,0 +1,90 @@
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type OpenidClientAuthorizationPermissionScope struct {
+	Id               string   `json:"id,omitempty"`
+	RealmId          string   `json:"-"`
+	ResourceServerId string   `json:"-"`
+	Name             string   `json:"name"`
+	Description      string   `json:"description"`
+	DecisionStrategy string   `json:"decisionStrategy"`
+	Policies         []string `json:"policies"`
+	Resources        []string `json:"resources"`
+	Scopes           []string `json:"scopes"`
+	ResourceType     string   `json:"resourceType"`
+}
+
+func (keycloakClient *KeycloakClient) GetOpenidClientAuthorizationPermissionScope(ctx context.Context, realm, resourceServerId, id string) (*OpenidClientAuthorizationPermissionScope, error) {
+	permission := OpenidClientAuthorizationPermissionScope{
+		RealmId:          realm,
+		ResourceServerId: resourceServerId,
+		Id:               id,
+	}
+
+	var policies []OpenidClientAuthorizationPolicy
+	var resources []OpenidClientAuthorizationResource
+	var scopes []OpenidClientAuthorizationScope
+
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/permission/%s", realm, resourceServerId, id), &permission, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/%s/associatedPolicies", realm, resourceServerId, id), &policies, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/permission/%s/resources", realm, resourceServerId, id), &resources, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/permission/%s/scopes", realm, resourceServerId, id), &scopes, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, policy := range policies {
+		permission.Policies = append(permission.Policies, policy.Id)
+	}
+
+	for _, resource := range resources {
+		permission.Resources = append(permission.Resources, resource.Id)
+	}
+
+	for _, resource := range scopes {
+		permission.Scopes = append(permission.Scopes, resource.Id)
+	}
+
+	return &permission, nil
+}
+
+func (keycloakClient *KeycloakClient) NewOpenidClientAuthorizationPermissionScope(ctx context.Context, permission *OpenidClientAuthorizationPermissionScope) error {
+	body, _, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/permission/scope", permission.RealmId, permission.ResourceServerId), permission)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(body, &permission)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (keycloakClient *KeycloakClient) UpdateOpenidClientAuthorizationPermissionScope(ctx context.Context, permission *OpenidClientAuthorizationPermissionScope) error {
+	err := keycloakClient.put(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/permission/scope/%s", permission.RealmId, permission.ResourceServerId, permission.Id), permission)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (keycloakClient *KeycloakClient) DeleteOpenidClientAuthorizationPermissionScope(ctx context.Context, realmId, resourceServerId, permissionId string) error {
+	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/permission/%s", realmId, resourceServerId, permissionId), nil)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -117,6 +117,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 			"keycloak_openid_client_authorization_client_scope_policy":   resourceKeycloakOpenidClientAuthorizationClientScopePolicy(),
 			"keycloak_openid_client_authorization_scope":                 resourceKeycloakOpenidClientAuthorizationScope(),
 			"keycloak_openid_client_authorization_permission":            resourceKeycloakOpenidClientAuthorizationPermission(),
+			"keycloak_openid_client_authorization_permission_scope":      resourceKeycloakOpenidClientAuthorizationPermissionScope(),
 			"keycloak_openid_client_service_account_role":                resourceKeycloakOpenidClientServiceAccountRole(),
 			"keycloak_openid_client_service_account_realm_role":          resourceKeycloakOpenidClientServiceAccountRealmRole(),
 			"keycloak_role":                                              resourceKeycloakRole(),

--- a/provider/resource_keycloak_openid_client_authorization_permission_scope.go
+++ b/provider/resource_keycloak_openid_client_authorization_permission_scope.go
@@ -1,0 +1,187 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakOpenidClientAuthorizationPermissionScope() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKeycloakOpenidClientAuthorizationPermissionScopeCreate,
+		ReadContext:   resourceKeycloakOpenidClientAuthorizationPermissionScopeRead,
+		DeleteContext: resourceKeycloakOpenidClientAuthorizationPermissionScopeDelete,
+		UpdateContext: resourceKeycloakOpenidClientAuthorizationPermissionScopeUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakOpenidClientAuthorizationPermissionScopeImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"resource_server_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"decision_strategy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(keycloakOpenidClientResourcePermissionDecisionStrategies, false),
+				Default:      "UNANIMOUS",
+			},
+			"policies": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"resources": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"resource_type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"scopes": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+		},
+	}
+}
+
+func getOpenidClientAuthorizationPermissionScopeFromData(data *schema.ResourceData) *keycloak.OpenidClientAuthorizationPermissionScope {
+	var policies []string
+	var resources []string
+	var scopes []string
+	if v, ok := data.GetOk("resources"); ok {
+		for _, resource := range v.(*schema.Set).List() {
+			resources = append(resources, resource.(string))
+		}
+	}
+	if v, ok := data.GetOk("policies"); ok {
+		for _, policy := range v.(*schema.Set).List() {
+			policies = append(policies, policy.(string))
+		}
+	}
+	if v, ok := data.GetOk("scopes"); ok {
+		for _, scope := range v.(*schema.Set).List() {
+			scopes = append(scopes, scope.(string))
+		}
+	}
+
+	permission := keycloak.OpenidClientAuthorizationPermissionScope{
+		Id:               data.Id(),
+		ResourceServerId: data.Get("resource_server_id").(string),
+		RealmId:          data.Get("realm_id").(string),
+		Description:      data.Get("description").(string),
+		Name:             data.Get("name").(string),
+		DecisionStrategy: data.Get("decision_strategy").(string),
+		Policies:         policies,
+		Scopes:           scopes,
+		Resources:        resources,
+		ResourceType:     data.Get("resource_type").(string),
+	}
+	return &permission
+}
+
+func setOpenidClientAuthorizationPermissionScopeData(data *schema.ResourceData, permission *keycloak.OpenidClientAuthorizationPermissionScope) {
+	data.SetId(permission.Id)
+	data.Set("resource_server_id", permission.ResourceServerId)
+	data.Set("realm_id", permission.RealmId)
+	data.Set("description", permission.Description)
+	data.Set("name", permission.Name)
+	data.Set("decision_strategy", permission.DecisionStrategy)
+	data.Set("policies", permission.Policies)
+	data.Set("scopes", permission.Scopes)
+	data.Set("resources", permission.Resources)
+	data.Set("resource_type", permission.ResourceType)
+}
+
+func resourceKeycloakOpenidClientAuthorizationPermissionScopeCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	permission := getOpenidClientAuthorizationPermissionScopeFromData(data)
+
+	err := keycloakClient.NewOpenidClientAuthorizationPermissionScope(ctx, permission)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	setOpenidClientAuthorizationPermissionScopeData(data, permission)
+
+	return resourceKeycloakOpenidClientAuthorizationPermissionScopeRead(ctx, data, meta)
+}
+
+func resourceKeycloakOpenidClientAuthorizationPermissionScopeRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	resourceServerId := data.Get("resource_server_id").(string)
+	id := data.Id()
+
+	permission, err := keycloakClient.GetOpenidClientAuthorizationPermissionScope(ctx, realmId, resourceServerId, id)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	setOpenidClientAuthorizationPermissionScopeData(data, permission)
+
+	return nil
+}
+
+func resourceKeycloakOpenidClientAuthorizationPermissionScopeUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	permission := getOpenidClientAuthorizationPermissionScopeFromData(data)
+
+	err := keycloakClient.UpdateOpenidClientAuthorizationPermissionScope(ctx, permission)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	setOpenidClientAuthorizationPermissionScopeData(data, permission)
+
+	return nil
+}
+
+func resourceKeycloakOpenidClientAuthorizationPermissionScopeDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	resourceServerId := data.Get("resource_server_id").(string)
+	id := data.Id()
+
+	return diag.FromErr(keycloakClient.DeleteOpenidClientAuthorizationPermissionScope(ctx, realmId, resourceServerId, id))
+}
+
+func resourceKeycloakOpenidClientAuthorizationPermissionScopeImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("Invalid import. Supported import formats: {{realmId}}/{{resourceServerId}}/{{permissionId}}")
+	}
+	d.Set("realm_id", parts[0])
+	d.Set("resource_server_id", parts[1])
+	d.SetId(parts[2])
+
+	return []*schema.ResourceData{d}, nil
+}


### PR DESCRIPTION
This PR currently has a copy of `keycloak_openid_client_permission` suffixed with 'scope'. This makes creating authz v2 FGAP permissions possible.

This PR is incomplete. Anyone able to help this go through?
* Missing tests.
* Better/other naming of the resource?
* Is this resource releasable by itself or is it part of a larger set?

I personally have no experience with Go or with this specific project.

Related to https://github.com/keycloak/terraform-provider-keycloak/issues/1444