### PR TITLE
feat(ldap): add remove_invalid_users_enabled to ldap_user_federation …

### DIFF
--- a/docs/resources/ldap_user_federation.md
+++ b/docs/resources/ldap_user_federation.md
@@ -85,6 +85,7 @@ resource "keycloak_ldap_user_federation" "ldap_user_federation" {
 - `connection_timeout` - (Optional) LDAP connection timeout in the format of a [Go duration string](https://golang.org/pkg/time/#Duration.String).
 - `read_timeout` - (Optional) LDAP read timeout in the format of a [Go duration string](https://golang.org/pkg/time/#Duration.String).
 - `pagination` - (Optional) When true, Keycloak assumes the LDAP server supports pagination. Defaults to `true`.
+- `remove_invalid_users_enabled` - (Optional) When `true`, Keycloak removes users from its local database that no longer exist in LDAP during sync. Defaults to `false`.
 - `batch_size_for_sync` - (Optional) The number of users to sync within a single transaction. Defaults to `1000`.
 - `full_sync_period` - (Optional) How frequently Keycloak should sync all LDAP users, in seconds. Omit this property to disable periodic full sync.
 - `changed_sync_period` - (Optional) How frequently Keycloak should sync changed LDAP users, in seconds. Omit this property to disable periodic changed users sync.

--- a/keycloak/ldap_user_federation.go
+++ b/keycloak/ldap_user_federation.go
@@ -49,9 +49,10 @@ type LdapUserFederation struct {
 	KeyTab                               string
 	KerberosRealm                        string
 
-	BatchSizeForSync  int
-	FullSyncPeriod    int // either a number, in milliseconds, or -1 if full sync is disabled
-	ChangedSyncPeriod int // either a number, in milliseconds, or -1 if changed sync is disabled
+	BatchSizeForSync           int
+	FullSyncPeriod             int // either a number, in milliseconds, or -1 if full sync is disabled
+	ChangedSyncPeriod          int // either a number, in milliseconds, or -1 if changed sync is disabled
+	RemoveInvalidUsersEnabled  bool
 
 	CachePolicy    string
 	MaxLifespan    string // duration string (ex: 1h30m)
@@ -136,6 +137,9 @@ func convertFromLdapUserFederationToComponent(ldap *LdapUserFederation) (*compon
 		},
 		"changedSyncPeriod": {
 			strconv.Itoa(ldap.ChangedSyncPeriod),
+		},
+		"removeInvalidUsers": {
+			strconv.FormatBool(ldap.RemoveInvalidUsersEnabled),
 		},
 
 		"serverPrincipal": {
@@ -305,6 +309,11 @@ func convertFromComponentToLdapUserFederation(component *component) (*LdapUserFe
 		return nil, err
 	}
 
+	removeInvalidUsersEnabled, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("removeInvalidUsers"))
+	if err != nil {
+		return nil, err
+	}
+
 	useKerberosForPasswordAuthentication, err := parseBoolAndTreatEmptyStringAsFalse(component.getConfig("useKerberosForPasswordAuthentication"))
 	if err != nil {
 		return nil, err
@@ -355,9 +364,10 @@ func convertFromComponentToLdapUserFederation(component *component) (*LdapUserFe
 		KeyTab:                               component.getConfig("keyTab"),
 		KerberosRealm:                        component.getConfig("kerberosRealm"),
 
-		BatchSizeForSync:  batchSizeForSync,
-		FullSyncPeriod:    fullSyncPeriod,
-		ChangedSyncPeriod: changedSyncPeriod,
+		BatchSizeForSync:          batchSizeForSync,
+		FullSyncPeriod:            fullSyncPeriod,
+		ChangedSyncPeriod:         changedSyncPeriod,
+		RemoveInvalidUsersEnabled: removeInvalidUsersEnabled,
 
 		CachePolicy: component.getConfig("cachePolicy"),
 	}

--- a/provider/resource_keycloak_ldap_user_federation.go
+++ b/provider/resource_keycloak_ldap_user_federation.go
@@ -210,6 +210,13 @@ func resourceKeycloakLdapUserFederation() *schema.Resource {
 				Description: "When true, Keycloak assumes the LDAP server supports pagination.",
 			},
 
+			"remove_invalid_users_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "When true, Keycloak removes users from its local database that no longer exist in LDAP during sync.",
+			},
+
 			"batch_size_for_sync": {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -372,9 +379,10 @@ func getLdapUserFederationFromData(data *schema.ResourceData, realmInternalId st
 		ReadTimeout:                 data.Get("read_timeout").(string),
 		Pagination:                  data.Get("pagination").(bool),
 
-		BatchSizeForSync:  data.Get("batch_size_for_sync").(int),
-		FullSyncPeriod:    data.Get("full_sync_period").(int),
-		ChangedSyncPeriod: data.Get("changed_sync_period").(int),
+		BatchSizeForSync:          data.Get("batch_size_for_sync").(int),
+		FullSyncPeriod:            data.Get("full_sync_period").(int),
+		ChangedSyncPeriod:         data.Get("changed_sync_period").(int),
+		RemoveInvalidUsersEnabled: data.Get("remove_invalid_users_enabled").(bool),
 	}
 
 	if cache, ok := data.GetOk("cache"); ok {
@@ -462,6 +470,7 @@ func setLdapUserFederationData(data *schema.ResourceData, ldap *keycloak.LdapUse
 	data.Set("batch_size_for_sync", ldap.BatchSizeForSync)
 	data.Set("full_sync_period", ldap.FullSyncPeriod)
 	data.Set("changed_sync_period", ldap.ChangedSyncPeriod)
+	data.Set("remove_invalid_users_enabled", ldap.RemoveInvalidUsersEnabled)
 
 	if _, ok := data.GetOk("cache"); ok {
 		cachePolicySettings := make(map[string]interface{})


### PR DESCRIPTION
Adds support for the `remove_invalid_users_enabled` attribute on the keycloak_ldap_user_federation resource. When enabled, Keycloak removes users from its local database that no longer exist in LDAP during sync.