### PR TITLE
fix(provider): set Host header via request.Host for additional_headers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -176,4 +176,4 @@ The following arguments are supported:
 - `tls_client_certificate` - (Optional) The TLS client certificate in PEM format when the keycloak server is configured with TLS mutual authentication.
 - `tls_client_private_key` - (Optional) The TLS client pkcs1 private key in PEM format when the keycloak server is configured with TLS mutual authentication.
 - `base_path` - (Optional) The base path used for accessing the Keycloak REST API.  Defaults to the environment variable `KEYCLOAK_BASE_PATH`, or an empty string if the environment variable is not specified. Note that users of the legacy distribution of Keycloak will need to set this attribute to `/auth`.
-- `additional_headers` - (Optional) A map of custom HTTP headers to add to each request to the Keycloak API.
+- `additional_headers` - (Optional) A map of custom HTTP headers to add to each request to the Keycloak API. The `Host` header is supported and will override the host used for the outgoing request.

--- a/keycloak/keycloak_client.go
+++ b/keycloak/keycloak_client.go
@@ -156,9 +156,7 @@ func (keycloakClient *KeycloakClient) login(ctx context.Context) error {
 			return err
 		}
 
-		for header, value := range keycloakClient.additionalHeaders {
-			accessTokenRequest.Header.Set(header, value)
-		}
+		keycloakClient.applyAdditionalHeaders(accessTokenRequest)
 
 		accessTokenRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -261,9 +259,7 @@ func (keycloakClient *KeycloakClient) Refresh(ctx context.Context) error {
 		return err
 	}
 
-	for header, value := range keycloakClient.additionalHeaders {
-		refreshTokenRequest.Header.Set(header, value)
-	}
+	keycloakClient.applyAdditionalHeaders(refreshTokenRequest)
 
 	refreshTokenRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
@@ -354,13 +350,21 @@ func (keycloakClient *KeycloakClient) getAuthenticationFormData(ctx context.Cont
 	return authenticationFormData, nil
 }
 
+func (keycloakClient *KeycloakClient) applyAdditionalHeaders(request *http.Request) {
+	for header, value := range keycloakClient.additionalHeaders {
+		if strings.EqualFold(header, "host") {
+			request.Host = value
+		} else {
+			request.Header.Set(header, value)
+		}
+	}
+}
+
 func (keycloakClient *KeycloakClient) addRequestHeaders(request *http.Request) {
 	tokenType := keycloakClient.clientCredentials.TokenType
 	accessToken := keycloakClient.clientCredentials.AccessToken
 
-	for header, value := range keycloakClient.additionalHeaders {
-		request.Header.Set(header, value)
-	}
+	keycloakClient.applyAdditionalHeaders(request)
 
 	request.Header.Set("Authorization", fmt.Sprintf("%s %s", tokenType, accessToken))
 	request.Header.Set("Accept", "application/json")

--- a/keycloak/keycloak_client_test.go
+++ b/keycloak/keycloak_client_test.go
@@ -2,6 +2,7 @@ package keycloak
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -82,6 +83,59 @@ func TestAccKeycloakClientConnectHttpsMtlsAuth(t *testing.T) {
 	// then try again to connect with Keycloak but this time via https with mtls client auth
 	mtlsKeycloakClient, err := NewKeycloakClient(ctx, keycloakUrl, "", os.Getenv("KEYCLOAK_ADMIN_URL"), os.Getenv("KEYCLOAK_CLIENT_ID"), os.Getenv("KEYCLOAK_CLIENT_SECRET"), os.Getenv("KEYCLOAK_REALM"), os.Getenv("KEYCLOAK_USER"), os.Getenv("KEYCLOAK_PASSWORD"), os.Getenv("KEYCLOAK_ACCESS_TOKEN"), "", "", os.Getenv("KEYCLOAK_JWT_TOKEN"), os.Getenv("KEYCLOAK_JWT_TOKEN_FILE"), true, clientTimeout, os.Getenv("KEYCLOAK_TLS_CA_CERT"), true, os.Getenv("KEYCLOAK_TLS_CLIENT_CERT"), os.Getenv("KEYCLOAK_TLS_CLIENT_KEY"), "", false, map[string]string{})
 	keycloakClientChecks(t, err, mtlsKeycloakClient, ctx)
+}
+
+func TestApplyAdditionalHeaders_HostHeader(t *testing.T) {
+	keycloakClient := &KeycloakClient{
+		additionalHeaders: map[string]string{
+			"Host":         "custom.host.example.com",
+			"X-Custom-Key": "custom-value",
+		},
+	}
+
+	request, err := http.NewRequest(http.MethodGet, "http://localhost/test", nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating request: %s", err)
+	}
+
+	keycloakClient.applyAdditionalHeaders(request)
+
+	if request.Host != "custom.host.example.com" {
+		t.Fatalf("expected request.Host to be 'custom.host.example.com', got '%s'", request.Host)
+	}
+
+	if request.Header.Get("Host") != "" {
+		t.Fatal("expected Host to not be set in request.Header (Go uses request.Host instead)")
+	}
+
+	if request.Header.Get("X-Custom-Key") != "custom-value" {
+		t.Fatalf("expected X-Custom-Key header to be 'custom-value', got '%s'", request.Header.Get("X-Custom-Key"))
+	}
+}
+
+func TestApplyAdditionalHeaders_HostHeaderCaseInsensitive(t *testing.T) {
+	variants := []string{"host", "HOST", "Host", "hOsT"}
+
+	for _, hostKey := range variants {
+		t.Run(hostKey, func(t *testing.T) {
+			keycloakClient := &KeycloakClient{
+				additionalHeaders: map[string]string{
+					hostKey: "custom.host.example.com",
+				},
+			}
+
+			request, err := http.NewRequest(http.MethodGet, "http://localhost/test", nil)
+			if err != nil {
+				t.Fatalf("unexpected error creating request: %s", err)
+			}
+
+			keycloakClient.applyAdditionalHeaders(request)
+
+			if request.Host != "custom.host.example.com" {
+				t.Fatalf("expected request.Host to be 'custom.host.example.com' for key '%s', got '%s'", hostKey, request.Host)
+			}
+		})
+	}
 }
 
 func checkClientTimeout(t *testing.T) int {


### PR DESCRIPTION
Setting Host in additional_headers is silently ignored because Go's net/http does not send Host from request.Header, it uses the request.Host field instead. This means request.Header.Set("Host", value) has no effect.

This PR detects when the Host key is used in additional_headers (case-insensitive) and sets request.Host instead. All other headers continue to use request.Header.Set() as before.

The Host-aware logic is extracted into applyAdditionalHeaders() and reused across all three call sites (login, token refresh, API requests) to avoid duplication. (As said in the Copilot Review)

Added Tests:
  - Added TestApplyAdditionalHeaders_HostHeader, verifies that Host is set on request.Host and non-Host headers still land in request.Header
  - Added TestApplyAdditionalHeaders_HostHeaderCaseInsensitive, verifies the fix works for host, HOST, Host, and hOsT