### PR TITLE
adds keycloak_spiffe_identity_provider resource

### DIFF
--- a/docs/resources/spiffe_identity_provider.md
+++ b/docs/resources/spiffe_identity_provider.md
@@ -46,7 +46,7 @@ resource "keycloak_openid_client" "spiffe_client" {
 - `realm` - (Required) The name of the realm. This is unique across Keycloak.
 - `alias` - (Required) The alias uniquely identifies an identity provider, and it is also used to build the redirect uri.
 - `trust_domain` - (Required) The SPIFFE trust domain. This must use the `spiffe://` scheme.
-- `bundle_endpoint` - (Required) The SPIFFE bundle endpoint or OpenID Connect JWKS endpoint exposing SPIFFE public keys. Depending your Keycloak Realm `ssl_required` setting, this may need to be an HTTPS URL.
+- `bundle_endpoint` - (Required) The SPIFFE bundle endpoint or OpenID Connect JWKS endpoint exposing SPIFFE public keys. Depending on your Keycloak Realm `ssl_required` setting, this may need to be an HTTPS URL.
 
 ## Import
 

--- a/docs/resources/spiffe_identity_provider.md
+++ b/docs/resources/spiffe_identity_provider.md
@@ -1,0 +1,59 @@
+---
+page_title: "keycloak_spiffe_identity_provider Resource"
+---
+
+# keycloak\_spiffe\_identity\_provider Resource
+
+Allows for creating and managing SPIFFE Identity Providers within Keycloak. A SPIFFE identity provider supports authenticating clients with SPIFFE JWT SVIDs.
+
+> **NOTICE:**
+> This is part of a preview keycloak feature. You need to enable this feature to be able to use this resource.
+> More information about enabling the preview feature can be found here: https://www.keycloak.org/docs/latest/server_admin/index.html#_identity_broker_spiffe
+
+## Example Usage
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+resource "keycloak_spiffe_identity_provider" "example" {
+  realm           = keycloak_realm.realm.id
+  alias           = "my-spiffe-idp"
+  trust_domain    = "spiffe://my-trust-domain"
+  bundle_endpoint = "https://example.com/spiffe/bundle"
+}
+
+resource "keycloak_openid_client" "spiffe_client" {
+  realm_id  = keycloak_realm.realm.id
+  client_id = "spiffe-client"
+
+  name    = "SPIFFE Client"
+  enabled = true
+
+  access_type               = "CONFIDENTIAL"
+  service_accounts_enabled  = true
+  client_authenticator_type = "federated-jwt"
+  extra_config = {
+    "jwt.credential.issuer" = keycloak_spiffe_identity_provider.example.alias
+    "jwt.credential.sub"    = "spiffe://my-trust-domain/workload"
+  }
+}
+```
+
+## Argument Reference
+
+- `realm` - (Required) The name of the realm. This is unique across Keycloak.
+- `alias` - (Required) The alias uniquely identifies an identity provider, and it is also used to build the redirect uri.
+- `trust_domain` - (Required) The SPIFFE trust domain. This must use the `spiffe://` scheme.
+- `bundle_endpoint` - (Required) The SPIFFE bundle endpoint or OpenID Connect JWKS endpoint exposing SPIFFE public keys. Depending your Keycloak Realm `ssl_required` setting, this may need to be an HTTPS URL.
+
+## Import
+
+Identity providers can be imported using the format `{{realm_id}}/{{idp_alias}}`, where `idp_alias` is the identity provider alias.
+
+Example:
+
+```bash
+$ terraform import keycloak_spiffe_identity_provider.realm_identity_provider my-realm/my-idp
+```

--- a/keycloak/identity_provider.go
+++ b/keycloak/identity_provider.go
@@ -53,6 +53,8 @@ type IdentityProviderConfig struct {
 	AuthnContextComparisonType      string                    `json:"authnContextComparisonType,omitempty"`
 	AuthnContextDeclRefs            types.KeycloakSliceQuoted `json:"authnContextDeclRefs,omitempty"`
 	Issuer                          string                    `json:"issuer,omitempty"`
+	TrustDomain                     string                    `json:"trustDomain,omitempty"`
+	BundleEndpoint                  string                    `json:"bundleEndpoint,omitempty"`
 	OrgRedirectModeEmailMatches     types.KeycloakBoolQuoted  `json:"kc.org.broker.redirect.mode.email-matches,omitempty"`
 	OrgDomain                       string                    `json:"kc.org.domain,omitempty"`
 	ApiUrl                          string                    `json:"apiUrl,omitempty"`

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -103,6 +103,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 			"keycloak_user_template_importer_identity_provider_mapper":   resourceKeycloakUserTemplateImporterIdentityProviderMapper(),
 			"keycloak_custom_identity_provider_mapper":                   resourceKeycloakCustomIdentityProviderMapper(),
 			"keycloak_kubernetes_identity_provider":                      resourceKeycloakKubernetesIdentityProvider(),
+			"keycloak_spiffe_identity_provider":                          resourceKeycloakSpiffeIdentityProvider(),
 			"keycloak_saml_identity_provider":                            resourceKeycloakSamlIdentityProvider(),
 			"keycloak_oidc_google_identity_provider":                     resourceKeycloakOidcGoogleIdentityProvider(),
 			"keycloak_oidc_facebook_identity_provider":                   resourceKeycloakOidcFacebookIdentityProvider(),

--- a/provider/resource_keycloak_spiffe_identity_provider.go
+++ b/provider/resource_keycloak_spiffe_identity_provider.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"dario.cat/mergo"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakSpiffeIdentityProvider() *schema.Resource {
+	spiffeSchema := map[string]*schema.Schema{
+		"provider_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "spiffe",
+			Description: "Provider ID, is always spiffe.",
+		},
+		"trust_domain": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The SPIFFE trust domain. This must use the spiffe:// scheme.",
+		},
+		"bundle_endpoint": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The SPIFFE bundle endpoint or OpenID Connect JWKS endpoint exposing SPIFFE public keys. Depending your Keycloak Realm \"ssl_required\" setting, this may need to be an HTTPS URL.",
+		},
+		"hide_on_login_page": {
+			Type:        schema.TypeBool,
+			Computed:    true,
+			Description: "This is always set to true for SPIFFE identity provider.",
+		},
+	}
+
+	spiffeResource := resourceKeycloakIdentityProvider()
+	spiffeResource.Schema = mergeSchemas(spiffeResource.Schema, spiffeSchema)
+	spiffeResource.CreateContext = resourceKeycloakIdentityProviderCreate(getSpiffeIdentityProviderFromData, setSpiffeIdentityProviderData)
+	spiffeResource.ReadContext = resourceKeycloakIdentityProviderRead(setSpiffeIdentityProviderData)
+	spiffeResource.UpdateContext = resourceKeycloakIdentityProviderUpdate(getSpiffeIdentityProviderFromData, setSpiffeIdentityProviderData)
+	return spiffeResource
+}
+
+func getSpiffeIdentityProviderFromData(data *schema.ResourceData, keycloakVersion *version.Version) (*keycloak.IdentityProvider, error) {
+	idp, defaultConfig := getIdentityProviderFromData(data, keycloakVersion)
+	idp.ProviderId = data.Get("provider_id").(string)
+	// The SPIFFE Identity Provider is only used for client authentication, so we always hide it on the login page.
+	idp.HideOnLogin = true
+
+	spiffeIdentityProviderConfig := &keycloak.IdentityProviderConfig{
+		TrustDomain:    data.Get("trust_domain").(string),
+		BundleEndpoint: data.Get("bundle_endpoint").(string),
+	}
+
+	if err := mergo.Merge(spiffeIdentityProviderConfig, defaultConfig); err != nil {
+		return nil, err
+	}
+
+	idp.Config = spiffeIdentityProviderConfig
+
+	return idp, nil
+}
+
+func setSpiffeIdentityProviderData(data *schema.ResourceData, identityProvider *keycloak.IdentityProvider, keycloakVersion *version.Version) error {
+	setIdentityProviderData(data, identityProvider, keycloakVersion)
+
+	data.Set("trust_domain", identityProvider.Config.TrustDomain)
+	data.Set("bundle_endpoint", identityProvider.Config.BundleEndpoint)
+
+	return nil
+}

--- a/provider/resource_keycloak_spiffe_identity_provider.go
+++ b/provider/resource_keycloak_spiffe_identity_provider.go
@@ -23,7 +23,7 @@ func resourceKeycloakSpiffeIdentityProvider() *schema.Resource {
 		"bundle_endpoint": {
 			Type:        schema.TypeString,
 			Required:    true,
-			Description: "The SPIFFE bundle endpoint or OpenID Connect JWKS endpoint exposing SPIFFE public keys. Depending your Keycloak Realm \"ssl_required\" setting, this may need to be an HTTPS URL.",
+			Description: "The SPIFFE bundle endpoint or OpenID Connect JWKS endpoint exposing SPIFFE public keys. Depending on your Keycloak Realm \"ssl_required\" setting, this may need to be an HTTPS URL.",
 		},
 		"hide_on_login_page": {
 			Type:        schema.TypeBool,

--- a/provider/resource_keycloak_spiffe_identity_provider.go
+++ b/provider/resource_keycloak_spiffe_identity_provider.go
@@ -63,6 +63,7 @@ func getSpiffeIdentityProviderFromData(data *schema.ResourceData, keycloakVersio
 func setSpiffeIdentityProviderData(data *schema.ResourceData, identityProvider *keycloak.IdentityProvider, keycloakVersion *version.Version) error {
 	setIdentityProviderData(data, identityProvider, keycloakVersion)
 
+	data.Set("provider_id", identityProvider.ProviderId)
 	data.Set("trust_domain", identityProvider.Config.TrustDomain)
 	data.Set("bundle_endpoint", identityProvider.Config.BundleEndpoint)
 

--- a/provider/resource_keycloak_spiffe_identity_provider_test.go
+++ b/provider/resource_keycloak_spiffe_identity_provider_test.go
@@ -1,0 +1,129 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func TestAccKeycloakSpiffeIdentityProvider_basic(t *testing.T) {
+	skipIfVersionIsLessThan(testCtx, t, keycloakClient, keycloak.Version_26_5)
+	t.Parallel()
+
+	spiffeName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakSpiffeIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakSpiffeIdentityProvider_basic(testAccRealm.Realm, spiffeName, "spiffe://example.org", "https://example.com/bundle"),
+				Check:  testAccCheckKeycloakSpiffeIdentityProviderExists("keycloak_spiffe_identity_provider.spiffe"),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakSpiffeIdentityProvider_insecureBundleEndpoint(t *testing.T) {
+	skipIfVersionIsLessThan(testCtx, t, keycloakClient, keycloak.Version_26_5)
+	t.Parallel()
+
+	realmName := acctest.RandomWithPrefix("tf-acc")
+	realm := &keycloak.Realm{
+		Realm:       realmName,
+		SslRequired: "none",
+	}
+
+	spiffeName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakSpiffeIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					err := keycloakClient.NewRealm(testCtx, realm)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testKeycloakSpiffeIdentityProvider_basic(realmName, spiffeName, "spiffe://example.org", "http://example.com/bundle"),
+				Check:  testAccCheckKeycloakSpiffeIdentityProviderExists("keycloak_spiffe_identity_provider.spiffe"),
+			},
+		},
+	})
+}
+
+func testKeycloakSpiffeIdentityProvider_basic(realm, alias, trustDomain, bundleEndpoint string) string {
+	return fmt.Sprintf(`
+		data "keycloak_realm" "realm" {
+			realm = "%s"
+		}
+
+		resource "keycloak_spiffe_identity_provider" "spiffe" {
+			realm           = data.keycloak_realm.realm.id
+			alias           = "%s"
+			trust_domain    = "%s"
+			bundle_endpoint = "%s"
+		}
+			`, realm, alias, trustDomain, bundleEndpoint)
+}
+
+func testAccCheckKeycloakSpiffeIdentityProviderExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		idp, err := getKeycloakSpiffeIdentityProviderFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		// SPIFFE identity provider should always be hidden on login page
+		if idp.HideOnLogin != true {
+			return fmt.Errorf("error checking if spiffe identity provider is hidden on login page: expected true but got %t", idp.HideOnLogin)
+		}
+
+		return nil
+	}
+}
+
+func getKeycloakSpiffeIdentityProviderFromState(s *terraform.State, resourceName string) (*keycloak.IdentityProvider, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("resource not found: %s", resourceName)
+	}
+
+	realm := rs.Primary.Attributes["realm"]
+	alias := rs.Primary.Attributes["alias"]
+
+	spiffe, err := keycloakClient.GetIdentityProvider(testCtx, realm, alias)
+	if err != nil {
+		return nil, fmt.Errorf("error getting spiffe identity provider config with alias %s: %s", alias, err)
+	}
+
+	return spiffe, nil
+}
+
+func testAccCheckKeycloakSpiffeIdentityProviderDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "keycloak_spiffe_identity_provider" {
+				continue
+			}
+
+			id := rs.Primary.ID
+			realm := rs.Primary.Attributes["realm"]
+
+			spiffe, _ := keycloakClient.GetIdentityProvider(testCtx, realm, id)
+			if spiffe != nil {
+				return fmt.Errorf("spiffe config with id %s still exists", id)
+			}
+		}
+
+		return nil
+	}
+}

--- a/provider/resource_keycloak_spiffe_identity_provider_test.go
+++ b/provider/resource_keycloak_spiffe_identity_provider_test.go
@@ -118,7 +118,15 @@ func testAccCheckKeycloakSpiffeIdentityProviderDestroy() resource.TestCheckFunc 
 			id := rs.Primary.ID
 			realm := rs.Primary.Attributes["realm"]
 
-			spiffe, _ := keycloakClient.GetIdentityProvider(testCtx, realm, id)
+			spiffe, err := keycloakClient.GetIdentityProvider(testCtx, realm, id)
+			if err != nil {
+				if keycloak.ErrorIs404(err) {
+					continue
+				}
+
+				return fmt.Errorf("error checking if spiffe config with id %s was destroyed: %w", id, err)
+			}
+
 			if spiffe != nil {
 				return fmt.Errorf("spiffe config with id %s still exists", id)
 			}


### PR DESCRIPTION
```
resource "keycloak_spiffe_identity_provider" "example" {
  realm           = keycloak_realm.realm.id
  alias           = "my-spiffe-idp"
  trust_domain    = "spiffe://my-trust-domain"
  bundle_endpoint = "https://example.com/spiffe/bundle"
}
```