### PR TITLE
Document allow_utf8 parameter for keycloak_realm smtp_server

### DIFF
--- a/docs/resources/realm.md
+++ b/docs/resources/realm.md
@@ -159,6 +159,7 @@ This block supports the following arguments:
 - `envelope_from` - (Optional) The email address uses for bounces.
 - `starttls` - (Optional) When `true`, enables StartTLS. Defaults to `false`.
 - `ssl` - (Optional) When `true`, enables SSL. Defaults to `false`.
+- `allow_utf8` - (Optional) When `true`, allows UTF-8 in the local part of the email address. Defaults to `false`.
 - `auth` - (Optional) Enables authentication to the SMTP server. Cannot be set alongside `token_auth`. This block supports the following arguments:
     - `username` - (Required) The SMTP server username.
     - `password` - (Required) The SMTP server password.


### PR DESCRIPTION
This parameter has been added with [this commit](https://github.com/keycloak/terraform-provider-keycloak/commit/2c7e6790525e2cc09c65070a96634b1e7983b4f1) but is missing in the documentation: https://registry.terraform.io/providers/keycloak/keycloak/latest/docs/resources/realm#smtp