### PR TITLE
feat(google-idp): expose login_hint as top-level attribute

### DIFF
--- a/docs/resources/oidc_google_identity_provider.md
+++ b/docs/resources/oidc_google_identity_provider.md
@@ -50,6 +50,7 @@ resource "keycloak_oidc_google_identity_provider" "google" {
 - `request_refresh_token` - (Optional) Sets the "access_type" query parameter to "offline" when redirecting to google authorization endpoint,to get a refresh token back. This is useful for using Token Exchange to retrieve a Google token to access Google APIs when the user is offline.
 - `default_scopes` - (Optional) The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to `openid profile email`.
 - `accepts_prompt_none_forward_from_client` - (Optional) When `true`, unauthenticated requests with `prompt=none` will be forwarded to Google instead of returning an error. Defaults to `false`.
+- `login_hint` - (Optional) Pass `login_hint` to the Google identity provider. Set to `"true"` to forward the `login_hint` query parameter from the inbound OIDC request to Google. The underlying Keycloak attribute `loginHint` is a boolean string, so the value should be `"true"` or `"false"`.
 - `disable_user_info` - (Optional) When `true`, disables the usage of the user info service to obtain additional user information. Defaults to `false`.
 - `hide_on_login_page` - (Optional) When `true`, this identity provider will be hidden on the login page. Defaults to `false`.
 - `sync_mode` - (Optional) The default sync mode to use for all mappers attached to this identity provider. Can be once of `IMPORT`, `FORCE`, or `LEGACY`.

--- a/provider/resource_keycloak_oidc_google_identity_provider.go
+++ b/provider/resource_keycloak_oidc_google_identity_provider.go
@@ -68,6 +68,11 @@ func resourceKeycloakOidcGoogleIdentityProvider() *schema.Resource {
 			Default:     false,
 			Description: "This is just used together with Identity Provider Authenticator or when kc_idp_hint points to this identity provider. In case that client sends a request with prompt=none and user is not yet authenticated, the error will not be directly returned to client, but the request with prompt=none will be forwarded to this identity provider.",
 		},
+		"login_hint": { //loginHint
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Pass login_hint to identity provider. Set to \"true\" to forward the login_hint client note (the underlying loginHint config attribute is a boolean string).",
+		},
 		"disable_user_info": { //disableUserInfo
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -108,6 +113,7 @@ func getOidcGoogleIdentityProviderFromData(data *schema.ResourceData, keycloakVe
 		OfflineAccess:               types.KeycloakBoolQuoted(data.Get("request_refresh_token").(bool)),
 		DefaultScope:                data.Get("default_scopes").(string),
 		AcceptsPromptNoneForwFrmClt: types.KeycloakBoolQuoted(data.Get("accepts_prompt_none_forward_from_client").(bool)),
+		LoginHint:                   data.Get("login_hint").(string),
 		UseJwksUrl:                  true,
 		DisableUserInfo:             types.KeycloakBoolQuoted(data.Get("disable_user_info").(bool)),
 	}
@@ -130,6 +136,7 @@ func setOidcGoogleIdentityProviderData(data *schema.ResourceData, identityProvid
 	data.Set("request_refresh_token", identityProvider.Config.OfflineAccess)
 	data.Set("default_scopes", identityProvider.Config.DefaultScope)
 	data.Set("accepts_prompt_none_forward_from_client", identityProvider.Config.AcceptsPromptNoneForwFrmClt)
+	data.Set("login_hint", identityProvider.Config.LoginHint)
 	data.Set("disable_user_info", identityProvider.Config.DisableUserInfo)
 
 	return nil

--- a/provider/resource_keycloak_oidc_google_identity_provider_test.go
+++ b/provider/resource_keycloak_oidc_google_identity_provider_test.go
@@ -89,6 +89,34 @@ resource "keycloak_oidc_google_identity_provider" "google" {
 	})
 }
 
+func TestAccKeycloakOidcGoogleIdentityProvider_loginHint(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakOidcGoogleIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_oidc_google_identity_provider" "google" {
+	realm             = data.keycloak_realm.realm.id
+	client_id         = "example_id"
+	client_secret     = "example_token"
+	login_hint        = "true"
+}
+	`, testAccRealm.Realm),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOidcGoogleIdentityProviderExists("keycloak_oidc_google_identity_provider.google"),
+					resource.TestCheckResourceAttr("keycloak_oidc_google_identity_provider.google", "login_hint", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakOidcGoogleIdentityProvider_extraConfig(t *testing.T) {
 	customConfigValue := acctest.RandomWithPrefix("tf-acc")
 


### PR DESCRIPTION
## What

Adds `login_hint` as a top-level attribute on `keycloak_oidc_google_identity_provider`, mirroring what `keycloak_oidc_identity_provider` and `keycloak_saml_identity_provider` already expose.

## Why

The underlying `keycloak.IdentityProviderConfig` struct already has the field:

```go
LoginHint string `json:"loginHint,omitempty"`
```

and Keycloak's `AbstractOAuth2IdentityProvider#createAuthorizationUrl` honors it for the Google IDP, since `GoogleIdentityProvider` extends `OIDCIdentityProvider` which extends `AbstractOAuth2IdentityProvider`. Closed upstream PR [keycloak/keycloak#8374](https://github.com/keycloak/keycloak/pull/8374) was specifically about adding the Google admin UI toggle - the runtime support is already there.

Today this attribute is unreachable through this provider:

- The Google resource schema doesn't expose it as a top-level attribute.
- Setting `extra_config = { loginHint = "true" }` is rejected with `extra_config key "loginHint" is not allowed, as it conflicts with a top-level schema attribute`, because `validateExtraConfig` reflects over `IdentityProviderConfig` and finds the matching JSON tag.
- Setting it out-of-band via `kcadm` is wiped on the next `terraform apply` because the resource PUTs a config that omits the field.

This leaves users with no way to enable `login_hint` forwarding for a Google IDP via Terraform, even though the underlying behavior is fully supported by Keycloak. This PR closes that gap.

## Changes

- `provider/resource_keycloak_oidc_google_identity_provider.go` - add `login_hint` to the schema; wire it through `getOidcGoogleIdentityProviderFromData` and `setOidcGoogleIdentityProviderData`.
- `provider/resource_keycloak_oidc_google_identity_provider_test.go` - add `TestAccKeycloakOidcGoogleIdentityProvider_loginHint` acceptance test.
- `docs/resources/oidc_google_identity_provider.md` - document the new attribute.

Note: the underlying Keycloak attribute `loginHint` is a boolean stored as a string (parsed via `Boolean.parseBoolean`), so values should be `"true"` or `"false"`. This matches how the generic OIDC and SAML resources already model the same attribute (`schema.TypeString`).

## Usage

```hcl
resource "keycloak_oidc_google_identity_provider" "google" {
  realm         = keycloak_realm.realm.id
  client_id     = var.google_client_id
  client_secret = var.google_client_secret
  login_hint    = "true"
}
```