### PR TITLE
fix(authentication-execution-config): use executionId-aware endpoint for GET

### DIFF
--- a/keycloak/authentication_execution_config.go
+++ b/keycloak/authentication_execution_config.go
@@ -25,7 +25,7 @@ func (keycloakClient *KeycloakClient) NewAuthenticationExecutionConfig(ctx conte
 
 // GetAuthenticationExecutionConfig https://www.keycloak.org/docs-api/latest/rest-api/index.html#_get_adminrealmsrealmauthenticationconfigid
 func (keycloakClient *KeycloakClient) GetAuthenticationExecutionConfig(ctx context.Context, config *AuthenticationExecutionConfig) error {
-	return keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/authentication/config/%s", config.RealmId, config.Id), config, nil)
+	return keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/authentication/executions/%s/config/%s", config.RealmId, config.ExecutionId, config.Id), config, nil)
 }
 
 // UpdateAuthenticationExecutionConfig https://www.keycloak.org/docs-api/latest/rest-api/index.html#_put_adminrealmsrealmauthenticationconfigid

--- a/provider/resource_keycloak_authentication_execution_config_test.go
+++ b/provider/resource_keycloak_authentication_execution_config_test.go
@@ -156,8 +156,9 @@ func testAccCheckKeycloakAuthenticationExecutionConfigDestroy(s *terraform.State
 		}
 
 		config := &keycloak.AuthenticationExecutionConfig{
-			RealmId: rs.Primary.Attributes["realm_id"],
-			Id:      rs.Primary.ID,
+			RealmId:     rs.Primary.Attributes["realm_id"],
+			ExecutionId: rs.Primary.Attributes["execution_id"],
+			Id:          rs.Primary.ID,
 		}
 		if err := keycloakClient.GetAuthenticationExecutionConfig(testCtx, config); err == nil {
 			return fmt.Errorf("authentication execution config still exists")


### PR DESCRIPTION
## What

Fixes `GetAuthenticationExecutionConfig` in the SDK so it queries the
endpoint that current Keycloak versions actually expose:

- before: `GET /realms/{realm}/authentication/config/{id}`
- after:  `GET /realms/{realm}/authentication/executions/{executionId}/config/{id}`

The first form returns `404` on recent Keycloak releases, which made
`keycloak_authentication_execution_config` resources unreadable after
creation/refresh.

## Why

`keycloak.AuthenticationExecutionConfig` already carries `ExecutionId`,
and other operations in this file (`NewAuthenticationExecutionConfig`,
`UpdateAuthenticationExecutionConfig`, `DeleteAuthenticationExecutionConfig`)
already use the executionId-scoped path. Only the GET was using the legacy
shape, which is why the resource only broke on read/refresh.

## Changes

- `keycloak/authentication_execution_config.go`: switch the GET URL to the
  executionId-scoped path.
- `provider/resource_keycloak_authentication_execution_config_test.go`:
  populate `ExecutionId` in the destroy check helper, otherwise the helper
  would call the new endpoint without the required path segment.

## Test plan

Existing acceptance tests cover this code path:

- `TestAccKeycloakAuthenticationExecutionConfig_basic`
- `TestAccKeycloakAuthenticationExecutionConfig_updateForcesNew`
- `TestAccKeycloakAuthenticationExecutionConfig_import`

Both `testAccCheckKeycloakAuthenticationExecutionConfigExists` and
`testAccCheckKeycloakAuthenticationExecutionConfigDestroy` exercise
`GetAuthenticationExecutionConfig`, so the fix is covered end-to-end.
