### PR TITLE
feat(authentication-execution): add flow_id and wire priority into create payload

### DIFF
--- a/docs/resources/authentication_execution.md
+++ b/docs/resources/authentication_execution.md
@@ -31,6 +31,7 @@ resource "keycloak_authentication_execution" "execution_one" {
   authenticator     = "auth-cookie"
   requirement       = "ALTERNATIVE"
   priority			= 10
+  flow_id           = "${keycloak_authentication_flow.flow.id}"
 }
 
 # second execution
@@ -40,6 +41,7 @@ resource "keycloak_authentication_execution" "execution_two" {
   authenticator     = "identity-provider-redirector"
   requirement       = "ALTERNATIVE"
   priority			= 20
+  flow_id           = "${keycloak_authentication_flow.flow.id}"
 }
 ```
 
@@ -47,9 +49,10 @@ resource "keycloak_authentication_execution" "execution_two" {
 
 - `realm_id` - (Required) The realm the authentication execution exists in.
 - `parent_flow_alias` - (Required) The alias of the flow this execution is attached to.
-- `authenticator` - (Required) The name of the authenticator. This can be found by experimenting with the GUI and looking at HTTP requests within the network tab of your browser's development tools.
+- `authenticator` - (Optional) The name of the authenticator. This can be found by experimenting with the GUI and looking at HTTP requests within the network tab of your browser's development tools.
 - `requirement`- (Optional) The requirement setting, which can be one of `REQUIRED`, `ALTERNATIVE`, `OPTIONAL`, `CONDITIONAL`, or `DISABLED`. Defaults to `DISABLED`.
 - `priority`- (Optional) The authenticator priority. Lower values will be executed prior higher values (Only supported by Keycloak >= 25).
+- `flow_id`- (Optional) The id of the flow this execution executes.
 
 ## Import
 

--- a/keycloak/authentication_execution.go
+++ b/keycloak/authentication_execution.go
@@ -10,7 +10,9 @@ import (
 // other fields can be provided to the API, but they are ignored
 // POST /realms/${realmId}/authentication/flows/${flowAlias}/executions/execution
 type authenticationExecutionCreate struct {
-	Provider string `json:"provider"` //authenticator of the execution
+	Provider string `json:"provider"` // authenticator of the execution
+	Priority int    `json:"priority,omitempty"`
+	FlowId   string `json:"flowId,omitempty"`
 }
 
 type authenticationExecutionRequirementUpdate struct {
@@ -26,12 +28,12 @@ type AuthenticationExecution struct {
 	Id                   string `json:"id"`
 	RealmId              string `json:"-"`
 	ParentFlowAlias      string `json:"-"`
-	Authenticator        string `json:"authenticator"` //can be any authenticator from GET realms/{realm}/authentication/authenticator-providers OR GET realms/{realm}/authentication/client-authenticator-providers OR GET realms/{realm}/authentication/form-action-providers
+	Authenticator        string `json:"authenticator"` // can be any authenticator from GET realms/{realm}/authentication/authenticator-providers OR GET realms/{realm}/authentication/client-authenticator-providers OR GET realms/{realm}/authentication/form-action-providers
 	AuthenticationConfig string `json:"authenticationConfig"`
 	AuthenticationFlow   bool   `json:"authenticationFlow"`
 	FlowId               string `json:"flowId"`
 	ParentFlowId         string `json:"parentFlow"`
-	Priority             int    `json:"priority"`
+	Priority             int    `json:"priority,omitempty"`
 	Requirement          string `json:"requirement"`
 }
 
@@ -48,8 +50,8 @@ type AuthenticationExecutionInfo struct {
 	Index                int    `json:"index"`
 	Level                int    `json:"level"`
 	ProviderId           string `json:"providerId"`
+	Priority             int    `json:"priority,omitempty"`
 	Requirement          string `json:"requirement"`
-	Priority             int    `json:"priority"`
 }
 
 type AuthenticationExecutionList []*AuthenticationExecutionInfo
@@ -121,7 +123,15 @@ func (keycloakClient *KeycloakClient) GetAuthenticationExecutionInfoFromProvider
 }
 
 func (keycloakClient *KeycloakClient) NewAuthenticationExecution(ctx context.Context, execution *AuthenticationExecution) error {
-	_, location, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/authentication/flows/%s/executions/execution", execution.RealmId, execution.ParentFlowAlias), &authenticationExecutionCreate{Provider: execution.Authenticator})
+	executionCreate := &authenticationExecutionCreate{
+		Provider: execution.Authenticator,
+		FlowId:   execution.FlowId,
+	}
+	if prioritySupported, _ := keycloakClient.VersionIsGreaterThanOrEqualTo(ctx, Version_25); prioritySupported {
+		executionCreate.Priority = execution.Priority
+	}
+
+	_, location, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/authentication/flows/%s/executions/execution", execution.RealmId, execution.ParentFlowAlias), executionCreate)
 	if err != nil {
 		return err
 	}
@@ -158,6 +168,9 @@ func (keycloakClient *KeycloakClient) UpdateAuthenticationExecution(ctx context.
 		Requirement:     execution.Requirement,
 		Priority:        execution.Priority,
 	}
+	if prioritySupported, _ := keycloakClient.VersionIsGreaterThanOrEqualTo(ctx, Version_25); prioritySupported {
+		authenticationExecutionUpdateRequirement.Priority = execution.Priority
+	}
 	return keycloakClient.UpdateAuthenticationExecutionRequirement(ctx, authenticationExecutionUpdateRequirement)
 }
 
@@ -177,16 +190,10 @@ func (keycloakClient *KeycloakClient) DeleteAuthenticationExecution(ctx context.
 
 func (keycloakClient *KeycloakClient) RaiseAuthenticationExecutionPriority(ctx context.Context, realmId, id string) error {
 	_, _, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/authentication/executions/%s/raise-priority", realmId, id), nil)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func (keycloakClient *KeycloakClient) LowerAuthenticationExecutionPriority(ctx context.Context, realmId, id string) error {
 	_, _, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/authentication/executions/%s/lower-priority", realmId, id), nil)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }

--- a/provider/resource_keycloak_authentication_execution.go
+++ b/provider/resource_keycloak_authentication_execution.go
@@ -34,18 +34,23 @@ func resourceKeycloakAuthenticationExecution() *schema.Resource {
 			},
 			"authenticator": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 			"requirement": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"REQUIRED", "ALTERNATIVE", "OPTIONAL", "CONDITIONAL", "DISABLED"}, false), //OPTIONAL is removed from 8.0.0 onwards
+				ValidateFunc: validation.StringInSlice([]string{"REQUIRED", "ALTERNATIVE", "OPTIONAL", "CONDITIONAL", "DISABLED"}, false), // OPTIONAL is removed from 8.0.0 onwards
 				Default:      "DISABLED",
 			},
 			"priority": {
 				Type:     schema.TypeInt,
 				Optional: true,
+			},
+			"flow_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
 			},
 		},
 	}
@@ -59,6 +64,7 @@ func mapFromDataToAuthenticationExecution(data *schema.ResourceData) *keycloak.A
 		Authenticator:   data.Get("authenticator").(string),
 		Requirement:     data.Get("requirement").(string),
 		Priority:        data.Get("priority").(int),
+		FlowId:          data.Get("flow_id").(string),
 	}
 
 	return authenticationExecution
@@ -73,6 +79,7 @@ func mapFromAuthenticationExecutionToData(ctx context.Context, keycloakClient *k
 	data.Set("authenticator", authenticationExecution.Authenticator)
 	data.Set("requirement", authenticationExecution.Requirement)
 	data.Set("priority", authenticationExecution.Priority)
+	data.Set("flow_id", authenticationExecution.FlowId)
 
 	return nil
 }


### PR DESCRIPTION
## What

Allow `keycloak_authentication_execution` to model a sub-flow execution
via a new optional `flow_id` attribute, and send `priority` directly in
the create payload (gated to Keycloak >= 25).

## Why

The Keycloak API exposes two kinds of executions on the same endpoint
(`POST /authentication/flows/{alias}/executions/execution`): leaf
executions (with `provider`) and sub-flow executions (with `flowId`).
The resource only modeled the leaf case, so nesting a flow as a step of
another flow was not possible from Terraform.

`priority` was already in the schema but ignored on create — the
execution was always appended and then re-ordered via raise/lower in a
follow-up call. Keycloak 25 accepts `priority` on create, which makes
the ordering deterministic and saves API round-trips.

## Changes

- `provider/resource_keycloak_authentication_execution.go`
  - Add `flow_id` (string, Optional, ForceNew).
  - `authenticator` becomes Optional (was Required) — a sub-flow
    execution does not need a provider id.
  - Read/write `flow_id` to/from `AuthenticationExecution`.
- `keycloak/authentication_execution.go`
  - Extend `authenticationExecutionCreate` with `Priority` and `FlowId`
    (both `omitempty`).
  - In `NewAuthenticationExecution`, always send `FlowId`; send
    `Priority` only when the Keycloak server is `>= 25`.
  - In `UpdateAuthenticationExecution`, propagate `Priority` into the
    requirement update payload, also gated to `>= 25`.
  - Mark `Priority` on `AuthenticationExecution` /
    `AuthenticationExecutionInfo` as `omitempty` so older Keycloak
    versions don't receive a zero value they didn't ask for.
- `docs/resources/authentication_execution.md`: document `flow_id` and
  the new optionality of `authenticator`.

## Backward compatibility

- Existing configs (leaf executions) keep working unchanged.
- On Keycloak < 25, the create payload is unchanged: `priority` is
  omitted and still applied via the existing update step.

## Usage

```hcl
resource "keycloak_authentication_flow" "subflow" {
  realm_id = data.keycloak_realm.realm.id
  alias    = "my-subflow"
}

resource "keycloak_authentication_execution" "nested" {
  realm_id          = data.keycloak_realm.realm.id
  parent_flow_alias = keycloak_authentication_flow.parent.alias
  flow_id           = keycloak_authentication_flow.subflow.id
  requirement       = "ALTERNATIVE"
  priority          = 10
}
```