### PR TITLE
feat: add import support for realm events, realm user profile and openid client scopes

### DIFF
--- a/provider/resource_keycloak_openid_client_default_scopes.go
+++ b/provider/resource_keycloak_openid_client_default_scopes.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,6 +17,9 @@ func resourceKeycloakOpenidClientDefaultScopes() *schema.Resource {
 		ReadContext:   resourceKeycloakOpenidClientDefaultScopesRead,
 		DeleteContext: resourceKeycloakOpenidClientDefaultScopesDelete,
 		UpdateContext: resourceKeycloakOpenidClientDefaultScopesReconcile,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakOpenidClientDefaultScopesImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"realm_id": {
 				Type:     schema.TypeString,
@@ -114,4 +119,44 @@ func resourceKeycloakOpenidClientDefaultScopesDelete(ctx context.Context, data *
 	defaultScopes := data.Get("default_scopes").(*schema.Set)
 
 	return diag.FromErr(keycloakClient.DetachOpenidClientDefaultScopes(ctx, realmId, clientId, interfaceSliceToStringSlice(defaultScopes.List())))
+}
+
+func resourceKeycloakOpenidClientDefaultScopesImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(data.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid import. Supported import formats: {{realmId}}/{{openidClientId}}")
+	}
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := parts[0]
+	clientId := parts[1]
+
+	keycloakOpenidClientDefaultScopes, err := keycloakClient.GetOpenidClientDefaultScopes(ctx, realmId, clientId)
+	if err != nil {
+		return nil, err
+	}
+
+	err = data.Set("realm_id", realmId)
+	if err != nil {
+		return nil, err
+	}
+	err = data.Set("client_id", clientId)
+	if err != nil {
+		return nil, err
+	}
+	var defaultScopes []string
+	for _, clientScope := range keycloakOpenidClientDefaultScopes {
+		defaultScopes = append(defaultScopes, clientScope.Name)
+	}
+	err = data.Set("default_scopes", defaultScopes)
+	if err != nil {
+		return nil, err
+	}
+
+	diagnostics := resourceKeycloakOpenidClientDefaultScopesRead(ctx, data, meta)
+	if diagnostics.HasError() {
+		return nil, errors.New(diagnostics[0].Summary)
+	}
+
+	return []*schema.ResourceData{data}, nil
 }

--- a/provider/resource_keycloak_openid_client_default_scopes_test.go
+++ b/provider/resource_keycloak_openid_client_default_scopes_test.go
@@ -30,6 +30,11 @@ func TestAccKeycloakOpenidClientDefaultScopes_basic(t *testing.T) {
 				Config: testKeycloakOpenidClientDefaultScopes_basic(client, clientScope),
 				Check:  testAccCheckKeycloakOpenidClientHasDefaultScopes("keycloak_openid_client_default_scopes.default_scopes", clientScopes),
 			},
+			{
+				ResourceName:      "keycloak_openid_client_default_scopes.default_scopes",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// we need a separate test step for destroy instead of using CheckDestroy because this resource is implicitly
 			// destroyed at the end of each test via destroying clients
 			{

--- a/provider/resource_keycloak_openid_client_optional_scopes.go
+++ b/provider/resource_keycloak_openid_client_optional_scopes.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,6 +17,9 @@ func resourceKeycloakOpenidClientOptionalScopes() *schema.Resource {
 		ReadContext:   resourceKeycloakOpenidClientOptionalScopesRead,
 		DeleteContext: resourceKeycloakOpenidClientOptionalScopesDelete,
 		UpdateContext: resourceKeycloakOpenidClientOptionalScopesReconcile,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakOpenidClientOptionalScopesImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"realm_id": {
 				Type:     schema.TypeString,
@@ -114,4 +119,44 @@ func resourceKeycloakOpenidClientOptionalScopesDelete(ctx context.Context, data 
 	optionalScopes := data.Get("optional_scopes").(*schema.Set)
 
 	return diag.FromErr(keycloakClient.DetachOpenidClientOptionalScopes(ctx, realmId, clientId, interfaceSliceToStringSlice(optionalScopes.List())))
+}
+
+func resourceKeycloakOpenidClientOptionalScopesImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(data.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid import. Supported import formats: {{realmId}}/{{openidClientId}}")
+	}
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := parts[0]
+	clientId := parts[1]
+
+	keycloakOpenidClientOptionalScopes, err := keycloakClient.GetOpenidClientOptionalScopes(ctx, realmId, clientId)
+	if err != nil {
+		return nil, err
+	}
+
+	err = data.Set("realm_id", realmId)
+	if err != nil {
+		return nil, err
+	}
+	err = data.Set("client_id", clientId)
+	if err != nil {
+		return nil, err
+	}
+	var optionalScopes []string
+	for _, clientScope := range keycloakOpenidClientOptionalScopes {
+		optionalScopes = append(optionalScopes, clientScope.Name)
+	}
+	err = data.Set("optional_scopes", optionalScopes)
+	if err != nil {
+		return nil, err
+	}
+
+	diagnostics := resourceKeycloakOpenidClientOptionalScopesRead(ctx, data, meta)
+	if diagnostics.HasError() {
+		return nil, errors.New(diagnostics[0].Summary)
+	}
+
+	return []*schema.ResourceData{data}, nil
 }

--- a/provider/resource_keycloak_openid_client_optional_scopes_test.go
+++ b/provider/resource_keycloak_openid_client_optional_scopes_test.go
@@ -32,6 +32,11 @@ func TestAccKeycloakOpenidClientOptionalScopes_basic(t *testing.T) {
 				Config: testKeycloakOpenidClientOptionalScopes_basic(client, clientScope),
 				Check:  testAccCheckKeycloakOpenidClientHasOptionalScopes("keycloak_openid_client_optional_scopes.optional_scopes", clientScopes),
 			},
+			{
+				ResourceName:      "keycloak_openid_client_optional_scopes.optional_scopes",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 			// we need a separate test step for destroy instead of using CheckDestroy because this resource is implicitly
 			// destroyed at the end of each test via destroying clients
 			{

--- a/provider/resource_keycloak_realm_events.go
+++ b/provider/resource_keycloak_realm_events.go
@@ -14,6 +14,9 @@ func resourceKeycloakRealmEvents() *schema.Resource {
 		ReadContext:   resourceKeycloakRealmEventsRead,
 		DeleteContext: resourceKeycloakRealmEventsDelete,
 		UpdateContext: resourceKeycloakRealmEventsUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakRealmEventsImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"realm_id": {
 				Type:     schema.TypeString,
@@ -152,4 +155,26 @@ func resourceKeycloakRealmEventsUpdate(ctx context.Context, data *schema.Resourc
 	setRealmEventsConfigData(data, realmEventsConfig)
 
 	return nil
+}
+
+func resourceKeycloakRealmEventsImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmEventsConfig, err := keycloakClient.GetRealmEventsConfig(ctx, data.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	err = data.Set("realm_id", data.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	if err := data.Set("enabled_event_types", realmEventsConfig.EnabledEventTypes); err != nil {
+		return nil, err
+	}
+
+	setRealmEventsConfigData(data, realmEventsConfig)
+
+	return []*schema.ResourceData{data}, nil
 }

--- a/provider/resource_keycloak_realm_events_test.go
+++ b/provider/resource_keycloak_realm_events_test.go
@@ -21,6 +21,11 @@ func TestAccKeycloakRealmEvents_basic(t *testing.T) {
 				Config: testKeycloakRealmEvents_basic(realmName),
 				Check:  testAccCheckKeycloakRealmEventsExists("keycloak_realm_events.realm_events"),
 			},
+			{
+				ResourceName:      "keycloak_realm_events.realm_events",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/provider/resource_keycloak_realm_user_profile.go
+++ b/provider/resource_keycloak_realm_user_profile.go
@@ -28,6 +28,9 @@ func resourceKeycloakRealmUserProfile() *schema.Resource {
 		ReadContext:   resourceKeycloakRealmUserProfileRead,
 		DeleteContext: resourceKeycloakRealmUserProfileDelete,
 		UpdateContext: resourceKeycloakRealmUserProfileUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakRealmUserProfileImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"realm_id": {
 				Type:     schema.TypeString,
@@ -540,4 +543,22 @@ func resourceKeycloakRealmUserProfileUpdate(ctx context.Context, data *schema.Re
 	}
 
 	return nil
+}
+
+func resourceKeycloakRealmUserProfileImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmUserProfile, err := keycloakClient.GetRealmUserProfile(ctx, data.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	err = data.Set("realm_id", data.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	setRealmUserProfileData(ctx, keycloakClient, data, realmUserProfile)
+
+	return []*schema.ResourceData{data}, nil
 }

--- a/provider/resource_keycloak_realm_user_profile_test.go
+++ b/provider/resource_keycloak_realm_user_profile_test.go
@@ -29,6 +29,11 @@ func TestAccKeycloakRealmUserProfile_enabledByDefault(t *testing.T) {
 				Config: testKeycloakRealmUserProfile_userProfileEnabledNotSet(realmName),
 				Check:  testAccCheckKeycloakRealmUserProfileExists("keycloak_realm_user_profile.realm_user_profile"),
 			},
+			{
+				ResourceName:      "keycloak_realm_user_profile.realm_user_profile",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## What

Adds `terraform import` support to four resources that previously had no `Importer` defined.

## Why

Without an `Importer`, these resources cannot be brought under Terraform management on existing realms or clients without recreating them, which is disruptive when adopting the provider on top of an already configured Keycloak.

## Changes

- `provider/resource_keycloak_realm_events.go`: `Importer` + `resourceKeycloakRealmEventsImport`. Import id: `{{realmId}}`.
- `provider/resource_keycloak_realm_user_profile.go`: `Importer` + `resourceKeycloakRealmUserProfileImport`. Import id: `{{realmId}}`.
- `provider/resource_keycloak_openid_client_default_scopes.go`: `Importer` + `resourceKeycloakOpenidClientDefaultScopesImport`. Import id: `{{realmId}}/{{openidClientId}}`.
- `provider/resource_keycloak_openid_client_optional_scopes.go`: `Importer` + `resourceKeycloakOpenidClientOptionalScopesImport`. Import id: `{{realmId}}/{{openidClientId}}`.
- Acceptance tests updated for all four resources with an `ImportState` / `ImportStateVerify` step.

## Backward compatibility

Pure addition. Existing configurations are unaffected.

## Usage

```bash
terraform import keycloak_realm_events.realm_events my-realm
terraform import keycloak_realm_user_profile.realm_user_profile my-realm
terraform import keycloak_openid_client_default_scopes.default_scopes my-realm/abc123-client-uuid
terraform import keycloak_openid_client_optional_scopes.optional_scopes my-realm/abc123-client-uuid
