### PR TITLE
fix: handle non-string types in keycloak_realm_user_profile validator config

### DIFF
--- a/provider/resource_keycloak_realm_user_profile.go
+++ b/provider/resource_keycloak_realm_user_profile.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -372,13 +373,16 @@ func getRealmUserProfileAttributeData(attr *keycloak.RealmUserProfileAttribute) 
 
 			validator["name"] = name
 
-			c := make(map[string]interface{})
+			c := make(map[string]string)
 			for k, v := range config {
-				if _, ok := v.([]interface{}); ok {
-					t, _ := json.Marshal(v)
+				switch tv := v.(type) {
+				case string:
+					c[k] = tv
+				case []interface{}:
+					t, _ := json.Marshal(tv)
 					c[k] = string(t)
-				} else {
-					c[k] = v
+				case float64:
+					c[k] = strconv.FormatFloat(tv, 'f', -1, 64)
 				}
 			}
 


### PR DESCRIPTION
## What

Fixes refresh/import on `keycloak_realm_user_profile` when a validator's `config` map contains values that Keycloak returns as something other than a string (e.g. a JSON number for `length.min`/`length.max`, or a JSON array for `options.options`).

## Why

The Terraform schema declares the validator `config` as `map[string]string`. The previous implementation of `getRealmUserProfileAttributeData` built `map[string]interface{}` from the API response, JSON-encoded only the `[]interface{}` case, and passed everything else through unchanged. When Keycloak returned a number or an array for a key the SDK could not coerce the result into the schema and the apply/refresh/import would fail.

## Changes

`provider/resource_keycloak_realm_user_profile.go`: in `getRealmUserProfileAttributeData`, switch the local map to `map[string]string` and convert each value with a type switch over the kinds the API actually returns:

- `string`: pass through.
- `[]interface{}`: JSON-encode to a string.
- `float64`: format with `strconv.FormatFloat(..., 'f', -1, 64)`.
