### PR TITLE
feat: add keycloak_openid_default_default_client_scopes and keycloak_openid_default_optional_client_scopes

### DIFF
--- a/docs/resources/openid_default_default_client_scopes.md
+++ b/docs/resources/openid_default_default_client_scopes.md
@@ -1,0 +1,54 @@
+---
+page_title: "keycloak_openid_default_default_client_scopes Resource"
+---
+
+# keycloak\_openid\_default\_default\_client\_scopes Resource
+
+Allows for managing the realm-level default client scopes that Keycloak attaches as **default** scopes to every newly
+created client. This is the realm equivalent of `keycloak_openid_client_default_scopes`, which works at the individual
+client level.
+
+The resource is **authoritative** over the realm's default-default scopes: scopes attached manually outside Terraform
+will be detached on the next apply, and scopes listed here that are missing from the realm will be added.
+
+This resource maps to the Keycloak Admin REST API endpoint
+`/admin/realms/{realm}/default-default-client-scopes`.
+
+## Example Usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+resource "keycloak_openid_client_scope" "extra_scope" {
+  realm_id = keycloak_realm.realm.id
+  name     = "extra-scope"
+}
+
+resource "keycloak_openid_default_default_client_scopes" "realm_defaults" {
+  realm_id = keycloak_realm.realm.id
+
+  default_scopes = [
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    keycloak_openid_client_scope.extra_scope.name,
+  ]
+}
+```
+
+## Argument Reference
+
+- `realm_id` - (Required) The realm to manage default-default client scopes for.
+- `default_scopes` - (Required) An ordered list of client scope names that should be configured as default scopes for the realm.
+
+## Import
+
+This resource can be imported using the realm id.
+
+```bash
+terraform import keycloak_openid_default_default_client_scopes.realm_defaults my-realm
+```

--- a/docs/resources/openid_default_optional_client_scopes.md
+++ b/docs/resources/openid_default_optional_client_scopes.md
@@ -1,0 +1,54 @@
+---
+page_title: "keycloak_openid_default_optional_client_scopes Resource"
+---
+
+# keycloak\_openid\_default\_optional\_client\_scopes Resource
+
+Allows for managing the realm-level optional client scopes that Keycloak attaches as **optional** scopes to every newly
+created client. This is the realm equivalent of `keycloak_openid_client_optional_scopes`, which works at the individual
+client level.
+
+The resource is **authoritative** over the realm's default-optional scopes: scopes attached manually outside Terraform
+will be detached on the next apply, and scopes listed here that are missing from the realm will be added.
+
+This resource maps to the Keycloak Admin REST API endpoint
+`/admin/realms/{realm}/default-optional-client-scopes`.
+
+## Example Usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+resource "keycloak_openid_client_scope" "extra_optional" {
+  realm_id = keycloak_realm.realm.id
+  name     = "extra-optional"
+}
+
+resource "keycloak_openid_default_optional_client_scopes" "realm_optionals" {
+  realm_id = keycloak_realm.realm.id
+
+  optional_scopes = [
+    "address",
+    "phone",
+    "offline_access",
+    "microprofile-jwt",
+    keycloak_openid_client_scope.extra_optional.name,
+  ]
+}
+```
+
+## Argument Reference
+
+- `realm_id` - (Required) The realm to manage default-optional client scopes for.
+- `optional_scopes` - (Required) An ordered list of client scope names that should be configured as optional scopes for the realm.
+
+## Import
+
+This resource can be imported using the realm id.
+
+```bash
+terraform import keycloak_openid_default_optional_client_scopes.realm_optionals my-realm
+```

--- a/keycloak/openid_default_default_client_scope.go
+++ b/keycloak/openid_default_default_client_scope.go
@@ -1,0 +1,42 @@
+package keycloak
+
+import (
+	"context"
+	"fmt"
+)
+
+func (keycloakClient *KeycloakClient) GetOpenidRealmDefaultDefaultClientScopes(ctx context.Context, realmId string) ([]*OpenidClientScope, error) {
+	var clientScopes []*OpenidClientScope
+
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/default-default-client-scopes", realmId), &clientScopes, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientScopes, nil
+}
+
+func (keycloakClient *KeycloakClient) GetOpenidRealmDefaultDefaultClientScope(ctx context.Context, realmId, clientScopeId string) (*OpenidClientScope, error) {
+	var clientScopes []OpenidClientScope
+
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/default-default-client-scopes", realmId), &clientScopes, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, clientScope := range clientScopes {
+		if clientScope.Id == clientScopeId {
+			return &clientScope, nil
+		}
+	}
+
+	return nil, err
+}
+
+func (keycloakClient *KeycloakClient) PutOpenidRealmDefaultDefaultClientScope(ctx context.Context, realmId, clientScopeId string) error {
+	return keycloakClient.put(ctx, fmt.Sprintf("/realms/%s/default-default-client-scopes/%s", realmId, clientScopeId), nil)
+}
+
+func (keycloakClient *KeycloakClient) DeleteOpenidRealmDefaultDefaultClientScope(ctx context.Context, realmId, clientScopeId string) error {
+	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/default-default-client-scopes/%s", realmId, clientScopeId), nil)
+}

--- a/keycloak/openid_default_optional_client_scope.go
+++ b/keycloak/openid_default_optional_client_scope.go
@@ -1,0 +1,42 @@
+package keycloak
+
+import (
+	"context"
+	"fmt"
+)
+
+func (keycloakClient *KeycloakClient) GetOpenidRealmDefaultOptionalClientScopes(ctx context.Context, realmId string) ([]*OpenidClientScope, error) {
+	var clientScopes []*OpenidClientScope
+
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/default-optional-client-scopes", realmId), &clientScopes, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientScopes, nil
+}
+
+func (keycloakClient *KeycloakClient) GetOpenidRealmDefaultOptionalClientScope(ctx context.Context, realmId, clientScopeId string) (*OpenidClientScope, error) {
+	var clientScopes []OpenidClientScope
+
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/default-optional-client-scopes", realmId), &clientScopes, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, clientScope := range clientScopes {
+		if clientScope.Id == clientScopeId {
+			return &clientScope, nil
+		}
+	}
+
+	return nil, err
+}
+
+func (keycloakClient *KeycloakClient) PutOpenidRealmDefaultOptionalClientScope(ctx context.Context, realmId, clientScopeId string) error {
+	return keycloakClient.put(ctx, fmt.Sprintf("/realms/%s/default-optional-client-scopes/%s", realmId, clientScopeId), nil)
+}
+
+func (keycloakClient *KeycloakClient) DeleteOpenidRealmDefaultOptionalClientScope(ctx context.Context, realmId, clientScopeId string) error {
+	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/default-optional-client-scopes/%s", realmId, clientScopeId), nil)
+}

--- a/keycloak/realm_client_scope.go
+++ b/keycloak/realm_client_scope.go
@@ -25,6 +25,17 @@ func (keycloakClient *KeycloakClient) GetRealmOptionalClientScopes(ctx context.C
 	return keycloakClient.getRealmClientScopesOfType(ctx, realmId, "optional")
 }
 
+func (keycloakClient *KeycloakClient) GetRealmClientScopes(ctx context.Context, realmId string) ([]*OpenidClientScope, error) {
+	var clientScopes []*OpenidClientScope
+
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/client-scopes", realmId), &clientScopes, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientScopes, nil
+}
+
 func (keycloakClient *KeycloakClient) resolveClientScopeNamesIntoIds(ctx context.Context, realmId string, scopeNames []string) ([]string, error) {
 	var scopeIds []string
 	var clientScopes []OpenidClientScope

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -88,6 +88,8 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 			"keycloak_organization":                                      resourceKeycloakOrganization(),
 			"keycloak_saml_client":                                       resourceKeycloakSamlClient(),
 			"keycloak_saml_client_scope":                                 resourceKeycloakSamlClientScope(),
+			"keycloak_openid_default_default_client_scopes":              resourceKeycloakOpenidDefaultDefaultClientScopes(),
+			"keycloak_openid_default_optional_client_scopes":             resourceKeycloakOpenidDefaultOptionalClientScopes(),
 			"keycloak_saml_client_default_scopes":                        resourceKeycloakSamlClientDefaultScopes(),
 			"keycloak_generic_client_protocol_mapper":                    resourceKeycloakGenericClientProtocolMapper(),
 			"keycloak_generic_client_role_mapper":                        resourceKeycloakGenericClientRoleMapper(),

--- a/provider/resource_keycloak_openid_default_default_client_scopes.go
+++ b/provider/resource_keycloak_openid_default_default_client_scopes.go
@@ -1,0 +1,184 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakOpenidDefaultDefaultClientScopes() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKeycloakOpenidDefaultDefaultClientScopesReconcile,
+		ReadContext:   resourceKeycloakOpenidDefaultDefaultClientScopesRead,
+		DeleteContext: resourceKeycloakOpenidDefaultDefaultClientScopesDelete,
+		UpdateContext: resourceKeycloakOpenidDefaultDefaultClientScopesReconcile,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakOpenidDefaultDefaultClientScopesImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"default_scopes": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceKeycloakOpenidDefaultDefaultClientScopesRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+
+	clientScopes, err := keycloakClient.GetOpenidRealmDefaultDefaultClientScopes(ctx, realmId)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	var defaultScopes []string
+	for _, clientScope := range clientScopes {
+		defaultScopes = append(defaultScopes, clientScope.Name)
+	}
+
+	err = data.Set("default_scopes", defaultScopes)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	data.SetId(realmId)
+
+	return nil
+}
+
+func resourceKeycloakOpenidDefaultDefaultClientScopesReconcile(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	tfOpenidDefaultDefaultScopes := interfaceSliceToStringSlice(data.Get("default_scopes").([]any))
+
+	keycloakOpenidDefaultDefaultScopes, err := keycloakClient.GetOpenidRealmDefaultDefaultClientScopes(ctx, realmId)
+	if err != nil {
+		if keycloak.ErrorIs404(err) {
+			return diag.FromErr(fmt.Errorf("validation error: realm with id %s does not exist", realmId))
+		}
+		return diag.FromErr(fmt.Errorf("validation error: error getting default default client scopes: %s", err.Error()))
+	}
+
+	diagnostics := detachDeletedDefaultScopes(ctx, keycloakOpenidDefaultDefaultScopes, tfOpenidDefaultDefaultScopes, err, keycloakClient, realmId)
+	if diagnostics != nil {
+		return diagnostics
+	}
+
+	if len(tfOpenidDefaultDefaultScopes) > 0 {
+		diagnostics = attachNewDefaultScopes(ctx, keycloakOpenidDefaultDefaultScopes, keycloakClient, realmId, tfOpenidDefaultDefaultScopes)
+		if diagnostics != nil {
+			return diagnostics
+		}
+	}
+
+	data.SetId(realmId)
+
+	return waitForDefaultUpdates(ctx, keycloakClient, realmId, tfOpenidDefaultDefaultScopes, 10)
+}
+
+func waitForDefaultUpdates(ctx context.Context, keycloakClient *keycloak.KeycloakClient, realmId string, scopes []string, times int) diag.Diagnostics {
+	if times == 0 {
+		return nil
+	}
+	keycloakOpenidDefaultDefaultScopes, err := keycloakClient.GetOpenidRealmDefaultDefaultClientScopes(ctx, realmId)
+	if err != nil {
+		if keycloak.ErrorIs404(err) {
+			return diag.FromErr(fmt.Errorf("validation error: realm with id %s does not exist", realmId))
+		}
+		return diag.FromErr(fmt.Errorf("validation error: error getting default default client scopes: %s", err.Error()))
+	}
+
+	if len(keycloakOpenidDefaultDefaultScopes) != len(scopes) {
+		time.Sleep(1 * time.Second)
+		return waitForDefaultUpdates(ctx, keycloakClient, realmId, scopes, times-1)
+	}
+	for _, keycloakOpenidDefaultDefaultScope := range keycloakOpenidDefaultDefaultScopes {
+		if !slices.Contains(scopes, keycloakOpenidDefaultDefaultScope.Name) {
+			time.Sleep(1 * time.Second)
+			return waitForDefaultUpdates(ctx, keycloakClient, realmId, scopes, times-1)
+		}
+	}
+	return nil
+}
+
+func detachDeletedDefaultScopes(ctx context.Context, keycloakOpenidDefaultDefaultScopes []*keycloak.OpenidClientScope, tfOpenidDefaultDefaultScopes []string, err error, keycloakClient *keycloak.KeycloakClient, realmId string) diag.Diagnostics {
+	for _, keycloakOpenidDefaultDefaultScope := range keycloakOpenidDefaultDefaultScopes {
+		if !slices.Contains(tfOpenidDefaultDefaultScopes, keycloakOpenidDefaultDefaultScope.Name) {
+			err = keycloakClient.DeleteOpenidRealmDefaultDefaultClientScope(ctx, realmId, keycloakOpenidDefaultDefaultScope.Id)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	return nil
+}
+
+func attachNewDefaultScopes(ctx context.Context, keycloakOpenidDefaultDefaultScopes []*keycloak.OpenidClientScope, keycloakClient *keycloak.KeycloakClient, realmId string, tfOpenidDefaultDefaultScopes []string) diag.Diagnostics {
+	keycloakClientScopes, err := keycloakClient.GetRealmClientScopes(ctx, realmId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	for _, keycloakClientScope := range keycloakClientScopes {
+		if slices.Contains(tfOpenidDefaultDefaultScopes, keycloakClientScope.Name) &&
+			!slices.ContainsFunc(keycloakOpenidDefaultDefaultScopes, func(e *keycloak.OpenidClientScope) bool {
+				return e.Id == keycloakClientScope.Id
+			}) {
+			err = keycloakClient.PutOpenidRealmDefaultDefaultClientScope(ctx, realmId, keycloakClientScope.Id)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	return nil
+}
+
+func resourceKeycloakOpenidDefaultDefaultClientScopesDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+
+	keycloakOpenidDefaultDefaultScopes, err := keycloakClient.GetOpenidRealmDefaultDefaultClientScopes(ctx, realmId)
+	if err != nil {
+		if keycloak.ErrorIs404(err) {
+			return diag.FromErr(fmt.Errorf("validation error: realm with id %s does not exist", realmId))
+		}
+		return diag.FromErr(err)
+	}
+
+	for _, keycloakClientScope := range keycloakOpenidDefaultDefaultScopes {
+		err = keycloakClient.DeleteOpenidRealmDefaultDefaultClientScope(ctx, realmId, keycloakClientScope.Id)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	return nil
+}
+
+func resourceKeycloakOpenidDefaultDefaultClientScopesImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	err := data.Set("realm_id", data.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	diagnostics := resourceKeycloakOpenidDefaultDefaultClientScopesRead(ctx, data, meta)
+	if diagnostics.HasError() {
+		return nil, errors.New(diagnostics[0].Summary)
+	}
+
+	return []*schema.ResourceData{data}, nil
+}

--- a/provider/resource_keycloak_openid_default_default_client_scopes_test.go
+++ b/provider/resource_keycloak_openid_default_default_client_scopes_test.go
@@ -1,0 +1,133 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccKeycloakOpenidDefaultDefaultClientScopes_basic(t *testing.T) {
+	realmName := acctest.RandomWithPrefix("tf-acc")
+	clientScopeName := acctest.RandomWithPrefix("tf-acc-scope")
+
+	expectedScopes := []string{"profile", "email", clientScopeName}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenidDefaultDefaultClientScopes_basic(realmName, clientScopeName, expectedScopes),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidRealmHasDefaultDefaultClientScopes(realmName, expectedScopes),
+				),
+			},
+			{
+				ResourceName:      "keycloak_openid_default_default_client_scopes.realm_defaults",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOpenidDefaultDefaultClientScopes_updateInPlace(t *testing.T) {
+	realmName := acctest.RandomWithPrefix("tf-acc")
+	scopeA := acctest.RandomWithPrefix("tf-acc-scope-a")
+	scopeB := acctest.RandomWithPrefix("tf-acc-scope-b")
+
+	withA := []string{"profile", scopeA}
+	withB := []string{"profile", scopeB}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenidDefaultDefaultClientScopes_twoScopes(realmName, scopeA, scopeB, withA),
+				Check:  testAccCheckKeycloakOpenidRealmHasDefaultDefaultClientScopes(realmName, withA),
+			},
+			{
+				Config: testKeycloakOpenidDefaultDefaultClientScopes_twoScopes(realmName, scopeA, scopeB, withB),
+				Check:  testAccCheckKeycloakOpenidRealmHasDefaultDefaultClientScopes(realmName, withB),
+			},
+		},
+	})
+}
+
+func testAccCheckKeycloakOpenidRealmHasDefaultDefaultClientScopes(realmName string, expectedScopes []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		actual, err := keycloakClient.GetOpenidRealmDefaultDefaultClientScopes(testCtx, realmName)
+		if err != nil {
+			return err
+		}
+
+		actualNames := make(map[string]struct{}, len(actual))
+		for _, scope := range actual {
+			actualNames[scope.Name] = struct{}{}
+		}
+
+		if len(actualNames) != len(expectedScopes) {
+			return fmt.Errorf("expected realm %q to have %d default-default client scopes, but got %d", realmName, len(expectedScopes), len(actualNames))
+		}
+
+		for _, expected := range expectedScopes {
+			if _, ok := actualNames[expected]; !ok {
+				return fmt.Errorf("expected realm %q default-default client scopes to contain %q", realmName, expected)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testKeycloakOpenidDefaultDefaultClientScopes_basic(realm, clientScope string, scopes []string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client_scope" "client_scope" {
+	realm_id = keycloak_realm.realm.id
+	name     = "%s"
+}
+
+resource "keycloak_openid_default_default_client_scopes" "realm_defaults" {
+	realm_id       = keycloak_realm.realm.id
+	default_scopes = %s
+
+	depends_on = [keycloak_openid_client_scope.client_scope]
+}
+	`, realm, clientScope, arrayOfStringsForTerraformResource(scopes))
+}
+
+func testKeycloakOpenidDefaultDefaultClientScopes_twoScopes(realm, scopeA, scopeB string, scopes []string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client_scope" "scope_a" {
+	realm_id = keycloak_realm.realm.id
+	name     = "%s"
+}
+
+resource "keycloak_openid_client_scope" "scope_b" {
+	realm_id = keycloak_realm.realm.id
+	name     = "%s"
+}
+
+resource "keycloak_openid_default_default_client_scopes" "realm_defaults" {
+	realm_id       = keycloak_realm.realm.id
+	default_scopes = %s
+
+	depends_on = [
+		keycloak_openid_client_scope.scope_a,
+		keycloak_openid_client_scope.scope_b,
+	]
+}
+	`, realm, scopeA, scopeB, arrayOfStringsForTerraformResource(scopes))
+}

--- a/provider/resource_keycloak_openid_default_optional_client_scopes.go
+++ b/provider/resource_keycloak_openid_default_optional_client_scopes.go
@@ -1,0 +1,184 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakOpenidDefaultOptionalClientScopes() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKeycloakOpenidDefaultOptionalClientScopesReconcile,
+		ReadContext:   resourceKeycloakOpenidDefaultOptionalClientScopesRead,
+		DeleteContext: resourceKeycloakOpenidDefaultOptionalClientScopesDelete,
+		UpdateContext: resourceKeycloakOpenidDefaultOptionalClientScopesReconcile,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakOpenidDefaultOptionalClientScopesImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"optional_scopes": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceKeycloakOpenidDefaultOptionalClientScopesRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+
+	clientScopes, err := keycloakClient.GetOpenidRealmDefaultOptionalClientScopes(ctx, realmId)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	var defaultScopes []string
+	for _, clientScope := range clientScopes {
+		defaultScopes = append(defaultScopes, clientScope.Name)
+	}
+
+	err = data.Set("optional_scopes", defaultScopes)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	data.SetId(realmId)
+
+	return nil
+}
+
+func resourceKeycloakOpenidDefaultOptionalClientScopesReconcile(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	tfOpenidDefaultOptionalScopes := interfaceSliceToStringSlice(data.Get("optional_scopes").([]any))
+
+	keycloakOpenidDefaultOptionalScopes, err := keycloakClient.GetOpenidRealmDefaultOptionalClientScopes(ctx, realmId)
+	if err != nil {
+		if keycloak.ErrorIs404(err) {
+			return diag.FromErr(fmt.Errorf("validation error: realm with id %s does not exist", realmId))
+		}
+		return diag.FromErr(fmt.Errorf("validation error: error getting default optional client scopes: %s", err.Error()))
+	}
+
+	diagnostics := detachDeletedOptionalScopes(ctx, keycloakOpenidDefaultOptionalScopes, tfOpenidDefaultOptionalScopes, err, keycloakClient, realmId)
+	if diagnostics != nil {
+		return diagnostics
+	}
+
+	if len(tfOpenidDefaultOptionalScopes) > 0 {
+		diagnostics = attachNewOptionalScopes(ctx, keycloakOpenidDefaultOptionalScopes, keycloakClient, realmId, tfOpenidDefaultOptionalScopes)
+		if diagnostics != nil {
+			return diagnostics
+		}
+	}
+
+	data.SetId(realmId)
+
+	return waitForOptionalUpdates(ctx, keycloakClient, realmId, tfOpenidDefaultOptionalScopes, 5)
+}
+
+func waitForOptionalUpdates(ctx context.Context, keycloakClient *keycloak.KeycloakClient, realmId string, scopes []string, times int) diag.Diagnostics {
+	if times == 0 {
+		return nil
+	}
+	keycloakOpenidDefaultOptionalScopes, err := keycloakClient.GetOpenidRealmDefaultOptionalClientScopes(ctx, realmId)
+	if err != nil {
+		if keycloak.ErrorIs404(err) {
+			return diag.FromErr(fmt.Errorf("validation error: realm with id %s does not exist", realmId))
+		}
+		return diag.FromErr(fmt.Errorf("validation error: error getting default optionals client scopes: %s", err.Error()))
+	}
+
+	if len(keycloakOpenidDefaultOptionalScopes) != len(scopes) {
+		time.Sleep(1 * time.Second)
+		return waitForOptionalUpdates(ctx, keycloakClient, realmId, scopes, times-1)
+	}
+	for _, keycloakOpenidDefaultOptionalScope := range keycloakOpenidDefaultOptionalScopes {
+		if !slices.Contains(scopes, keycloakOpenidDefaultOptionalScope.Name) {
+			time.Sleep(1 * time.Second)
+			return waitForOptionalUpdates(ctx, keycloakClient, realmId, scopes, times-1)
+		}
+	}
+	return nil
+}
+
+func detachDeletedOptionalScopes(ctx context.Context, keycloakOpenidDefaultOptionalScopes []*keycloak.OpenidClientScope, tfOpenidDefaultOptionalScopes []string, err error, keycloakClient *keycloak.KeycloakClient, realmId string) diag.Diagnostics {
+	for _, keycloakOpenidDefaultOptionalScope := range keycloakOpenidDefaultOptionalScopes {
+		if !slices.Contains(tfOpenidDefaultOptionalScopes, keycloakOpenidDefaultOptionalScope.Name) {
+			err = keycloakClient.DeleteOpenidRealmDefaultOptionalClientScope(ctx, realmId, keycloakOpenidDefaultOptionalScope.Id)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	return nil
+}
+
+func attachNewOptionalScopes(ctx context.Context, keycloakOpenidDefaultOptionalScopes []*keycloak.OpenidClientScope, keycloakClient *keycloak.KeycloakClient, realmId string, tfOpenidDefaultOptionalScopes []string) diag.Diagnostics {
+	keycloakClientScopes, err := keycloakClient.GetRealmClientScopes(ctx, realmId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	for _, keycloakClientScope := range keycloakClientScopes {
+		if slices.Contains(tfOpenidDefaultOptionalScopes, keycloakClientScope.Name) &&
+			!slices.ContainsFunc(keycloakOpenidDefaultOptionalScopes, func(e *keycloak.OpenidClientScope) bool {
+				return e.Id == keycloakClientScope.Id
+			}) {
+			err = keycloakClient.PutOpenidRealmDefaultOptionalClientScope(ctx, realmId, keycloakClientScope.Id)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	return nil
+}
+
+func resourceKeycloakOpenidDefaultOptionalClientScopesDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+
+	keycloakOpenidDefaultOptionalScopes, err := keycloakClient.GetOpenidRealmDefaultOptionalClientScopes(ctx, realmId)
+	if err != nil {
+		if keycloak.ErrorIs404(err) {
+			return diag.FromErr(fmt.Errorf("validation error: realm with id %s does not exist", realmId))
+		}
+		return diag.FromErr(err)
+	}
+
+	for _, keycloakClientScope := range keycloakOpenidDefaultOptionalScopes {
+		err = keycloakClient.DeleteOpenidRealmDefaultOptionalClientScope(ctx, realmId, keycloakClientScope.Id)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	return nil
+}
+
+func resourceKeycloakOpenidDefaultOptionalClientScopesImport(ctx context.Context, data *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	err := data.Set("realm_id", data.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	diagnostics := resourceKeycloakOpenidDefaultOptionalClientScopesRead(ctx, data, meta)
+	if diagnostics.HasError() {
+		return nil, errors.New(diagnostics[0].Summary)
+	}
+
+	return []*schema.ResourceData{data}, nil
+}

--- a/provider/resource_keycloak_openid_default_optional_client_scopes_test.go
+++ b/provider/resource_keycloak_openid_default_optional_client_scopes_test.go
@@ -1,0 +1,133 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccKeycloakOpenidDefaultOptionalClientScopes_basic(t *testing.T) {
+	realmName := acctest.RandomWithPrefix("tf-acc")
+	clientScopeName := acctest.RandomWithPrefix("tf-acc-scope")
+
+	expectedScopes := []string{"address", "phone", clientScopeName}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenidDefaultOptionalClientScopes_basic(realmName, clientScopeName, expectedScopes),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidRealmHasDefaultOptionalClientScopes(realmName, expectedScopes),
+				),
+			},
+			{
+				ResourceName:      "keycloak_openid_default_optional_client_scopes.realm_optionals",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOpenidDefaultOptionalClientScopes_updateInPlace(t *testing.T) {
+	realmName := acctest.RandomWithPrefix("tf-acc")
+	scopeA := acctest.RandomWithPrefix("tf-acc-scope-a")
+	scopeB := acctest.RandomWithPrefix("tf-acc-scope-b")
+
+	withA := []string{"address", scopeA}
+	withB := []string{"address", scopeB}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenidDefaultOptionalClientScopes_twoScopes(realmName, scopeA, scopeB, withA),
+				Check:  testAccCheckKeycloakOpenidRealmHasDefaultOptionalClientScopes(realmName, withA),
+			},
+			{
+				Config: testKeycloakOpenidDefaultOptionalClientScopes_twoScopes(realmName, scopeA, scopeB, withB),
+				Check:  testAccCheckKeycloakOpenidRealmHasDefaultOptionalClientScopes(realmName, withB),
+			},
+		},
+	})
+}
+
+func testAccCheckKeycloakOpenidRealmHasDefaultOptionalClientScopes(realmName string, expectedScopes []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		actual, err := keycloakClient.GetOpenidRealmDefaultOptionalClientScopes(testCtx, realmName)
+		if err != nil {
+			return err
+		}
+
+		actualNames := make(map[string]struct{}, len(actual))
+		for _, scope := range actual {
+			actualNames[scope.Name] = struct{}{}
+		}
+
+		if len(actualNames) != len(expectedScopes) {
+			return fmt.Errorf("expected realm %q to have %d default-optional client scopes, but got %d", realmName, len(expectedScopes), len(actualNames))
+		}
+
+		for _, expected := range expectedScopes {
+			if _, ok := actualNames[expected]; !ok {
+				return fmt.Errorf("expected realm %q default-optional client scopes to contain %q", realmName, expected)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testKeycloakOpenidDefaultOptionalClientScopes_basic(realm, clientScope string, scopes []string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client_scope" "client_scope" {
+	realm_id = keycloak_realm.realm.id
+	name     = "%s"
+}
+
+resource "keycloak_openid_default_optional_client_scopes" "realm_optionals" {
+	realm_id        = keycloak_realm.realm.id
+	optional_scopes = %s
+
+	depends_on = [keycloak_openid_client_scope.client_scope]
+}
+	`, realm, clientScope, arrayOfStringsForTerraformResource(scopes))
+}
+
+func testKeycloakOpenidDefaultOptionalClientScopes_twoScopes(realm, scopeA, scopeB string, scopes []string) string {
+	return fmt.Sprintf(`
+resource "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client_scope" "scope_a" {
+	realm_id = keycloak_realm.realm.id
+	name     = "%s"
+}
+
+resource "keycloak_openid_client_scope" "scope_b" {
+	realm_id = keycloak_realm.realm.id
+	name     = "%s"
+}
+
+resource "keycloak_openid_default_optional_client_scopes" "realm_optionals" {
+	realm_id        = keycloak_realm.realm.id
+	optional_scopes = %s
+
+	depends_on = [
+		keycloak_openid_client_scope.scope_a,
+		keycloak_openid_client_scope.scope_b,
+	]
+}
+	`, realm, scopeA, scopeB, arrayOfStringsForTerraformResource(scopes))
+}


### PR DESCRIPTION
## What

Adds two new resources to manage realm-level default and optional client scopes:

- `keycloak_openid_default_default_client_scopes`
- `keycloak_openid_default_optional_client_scopes`

These cover the Keycloak Admin REST API endpoints `/realms/{realm}/default-default-client-scopes` and `/realms/{realm}/default-optional-client-scopes`.

## Why

The provider already supports per-client scopes (`keycloak_openid_client_default_scopes` / `_optional_scopes`), but configuring the **realm-level** templates that Keycloak applies to every newly created client required dropping out of Terraform.

## Changes

- `keycloak/openid_default_default_client_scope.go`, `keycloak/openid_default_optional_client_scope.go`: new SDK functions `GetOpenidRealmDefaultDefault... / DefaultOptional...` with Get/Put/Delete.
- `keycloak/realm_client_scope.go`: helper `GetRealmClientScopes` that lists every client scope in a realm (used to resolve names to ids during reconcile).
- `provider/resource_keycloak_openid_default_default_client_scopes.go`, `provider/resource_keycloak_openid_default_optional_client_scopes.go`: new resources with `Create/Read/Update/Delete/Import`. Both are authoritative: scopes attached manually outside Terraform are detached on the next apply, and scopes listed in config but missing on the realm are added back. Each reconcile polls the API a few times to absorb the eventual consistency the endpoints occasionally show right after a Put/Delete.
- `provider/provider.go`: registers the two new resources.
- `provider/resource_keycloak_openid_default_default_client_scopes_test.go`, `provider/resource_keycloak_openid_default_optional_client_scopes_test.go`: acceptance tests covering basic create + import roundtrip and in-place update across two scopes. Each test creates its own realm so the existing `testAccRealm` is untouched (since the resource is realm-authoritative).
- `docs/resources/openid_default_default_client_scopes.md`, `docs/resources/openid_default_optional_client_scopes.md`: usage and import docs.

## Backward compatibility

Pure addition. No existing resources or data sources are affected.

## Usage

```hcl
resource "keycloak_openid_default_default_client_scopes" "realm_defaults" {
  realm_id       = keycloak_realm.realm.id
  default_scopes = ["profile", "email", "roles", "web-origins"]
}

resource "keycloak_openid_default_optional_client_scopes" "realm_optionals" {
  realm_id        = keycloak_realm.realm.id
  optional_scopes = ["address", "phone", "offline_access", "microprofile-jwt"]
}
