### PR TITLE
fix: Add ability to update SMTP servers OAUTH client secret

### DIFF
--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -778,6 +778,21 @@ func getRealmSMTPPasswordFromData(data *schema.ResourceData) (string, bool) {
 	return "", false
 }
 
+func getRealmSMTPClientSecretFromData(data *schema.ResourceData) (string, bool) {
+	if v, ok := data.GetOk("smtp_server"); ok {
+		smtpSettings := v.([]interface{})[0].(map[string]interface{})
+		tokenConfig := smtpSettings["token_auth"].([]interface{})
+
+		if len(tokenConfig) == 1 {
+			return tokenConfig[0].(map[string]interface{})["client_secret"].(string), true
+		}
+
+		return "", false
+	}
+
+	return "", false
+}
+
 func setRealmFlowBindings(data *schema.ResourceData, realm *keycloak.Realm, keycloakVersion *version.Version) {
 	if flow, ok := data.GetOk("browser_flow"); ok {
 		realm.BrowserFlow = stringPointer(flow.(string))
@@ -1603,9 +1618,13 @@ func resourceKeycloakRealmRead(ctx context.Context, data *schema.ResourceData, m
 		return handleNotFoundError(ctx, err, data)
 	}
 
-	// we can't trust the API to set this field correctly since it just responds with "**********" this implies a 'password only' change will not be detected
+	// we can't trust the API to set these fields correctly since it just responds with "**********" this implies a 'password/client secret only' change will not be detected
 	if smtpPassword, ok := getRealmSMTPPasswordFromData(data); ok {
 		realm.SmtpServer.Password = smtpPassword
+	}
+
+	if smtpClientSecret, ok := getRealmSMTPClientSecretFromData(data); ok {
+		realm.SmtpServer.AuthTokenClientSecret = smtpClientSecret
 	}
 
 	if _, ok := data.GetOk("terraform_deletion_protection"); !ok {

--- a/provider/resource_keycloak_realm.go
+++ b/provider/resource_keycloak_realm.go
@@ -796,6 +796,21 @@ func getRealmSMTPPasswordFromData(data *schema.ResourceData) (string, bool) {
 	return "", false
 }
 
+func getRealmSMTPClientSecretFromData(data *schema.ResourceData) (string, bool) {
+	if v, ok := data.GetOk("smtp_server"); ok {
+		smtpSettings := v.([]interface{})[0].(map[string]interface{})
+		tokenConfig := smtpSettings["token_auth"].([]interface{})
+
+		if len(tokenConfig) == 1 {
+			return tokenConfig[0].(map[string]interface{})["client_secret"].(string), true
+		}
+
+		return "", false
+	}
+
+	return "", false
+}
+
 func setRealmFlowBindings(data *schema.ResourceData, realm *keycloak.Realm, keycloakVersion *version.Version) {
 	if flow, ok := data.GetOk("browser_flow"); ok {
 		realm.BrowserFlow = stringPointer(flow.(string))
@@ -1685,9 +1700,13 @@ func resourceKeycloakRealmRead(ctx context.Context, data *schema.ResourceData, m
 		return handleNotFoundError(ctx, err, data)
 	}
 
-	// we can't trust the API to set this field correctly since it just responds with "**********" this implies a 'password only' change will not be detected
+	// we can't trust the API to set these fields correctly since it just responds with "**********" this implies a 'password/client secret only' change will not be detected
 	if smtpPassword, ok := getRealmSMTPPasswordFromData(data); ok {
 		realm.SmtpServer.Password = smtpPassword
+	}
+
+	if smtpClientSecret, ok := getRealmSMTPClientSecretFromData(data); ok {
+		realm.SmtpServer.AuthTokenClientSecret = smtpClientSecret
 	}
 
 	if _, ok := data.GetOk("terraform_deletion_protection"); !ok {

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -163,12 +163,12 @@ func TestAccKeycloakRealm_SmtpServerOauth(t *testing.T) {
 		CheckDestroy:             testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost.com", "admin@myhost.com", "user"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user"),
+				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble", "wiggle"),
+				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble", "wiggle"),
 			},
 			{
 				Config: testKeycloakRealm_basic(realm, realm, realmDisplayNameHtml),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "", "", ""),
+				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "", "", "", "", "", "", ""),
 			},
 		},
 	})
@@ -183,12 +183,12 @@ func TestAccKeycloakRealm_SmtpServerOauthUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost.com", "admin@myhost.com", "user"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user"),
+				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble", "wiggle"),
+				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble", "wiggle"),
 			},
 			{
-				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost2.com", "admin@myhost2.com", "user2"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost2.com", "admin@myhost2.com", "user2"),
+				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost2.com", "admin@myhost2.com", "user2", "wibble2.com", "wibble2", "wobble2", "wiggle2"),
+				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "myhost2.com", "admin@myhost2.com", "user2", "wibble2.com", "wibble2", "wobble2", "wiggle2"),
 			},
 		},
 	})
@@ -1239,6 +1239,40 @@ func testAccCheckKeycloakRealmSmtp(resourceName, host, from, user string) resour
 		if realm.SmtpServer.User != user {
 			return fmt.Errorf("expected realm %s to have smtp user set to %s, but was %s", realm.Realm, user, realm.SmtpServer.User)
 		}
+func testAccCheckKeycloakRealmSmtpOauth(resourceName, host, from, user, url, client_id, client_secret, scope string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		realm, err := getRealmFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if realm.SmtpServer.Host != host {
+			return fmt.Errorf("expected realm %s to have smtp host set to %s, but was %s", realm.Realm, host, realm.SmtpServer.Host)
+		}
+
+		if realm.SmtpServer.From != from {
+			return fmt.Errorf("expected realm %s to have smtp from set to %s, but was %s", realm.Realm, from, realm.SmtpServer.From)
+		}
+
+		if realm.SmtpServer.User != user {
+			return fmt.Errorf("expected realm %s to have smtp user set to %s, but was %s", realm.Realm, user, realm.SmtpServer.User)
+		}
+
+		if realm.SmtpServer.AuthTokenUrl != url {
+			return fmt.Errorf("expected realm %s to have smtp url set to %s, but was %s", realm.Realm, url, realm.SmtpServer.AuthTokenUrl)
+		}
+
+		if realm.SmtpServer.AuthTokenClientId != client_id {
+			return fmt.Errorf("expected realm %s to have smtp client id set to %s, but was %s", realm.Realm, client_id, realm.SmtpServer.AuthTokenClientId)
+		}
+
+		if realm.SmtpServer.AuthTokenClientSecret != client_secret {
+			return fmt.Errorf("expected realm %s to have smtp client secret set to %s, but was %s", realm.Realm, client_secret, realm.SmtpServer.AuthTokenClientSecret)
+		}
+
+		if realm.SmtpServer.AuthTokenScope != scope {
+			return fmt.Errorf("expected realm %s to have smtp scope set to %s, but was %s", realm.Realm, scope, realm.SmtpServer.AuthTokenScope)
+		}
 
 		return nil
 	}
@@ -1506,7 +1540,7 @@ resource "keycloak_realm" "realm" {
 	`, realm, realm, host, from, user)
 }
 
-func testKeycloakRealm_WithSmtpServerWithOauth(realm, host, from, user string) string {
+func testKeycloakRealm_WithSmtpServerWithOauth(realm, host, from, user, url, client_id, client_secret, scope string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
 	realm = "%s"
@@ -1524,14 +1558,14 @@ resource "keycloak_realm" "realm" {
 		envelope_from = "nottom@myhost.com"
 		token_auth {
 			username      = "%s"
-			url           = "wibble.com"
-			client_id     = "wibble"
-			client_secret = "wobble"
-			scope         = "wiggle"
+			url           = "%s"
+			client_id     = "%s"
+			client_secret = "%s"
+			scope         = "%s"
 		}
 	}
 }
-	`, realm, realm, host, from, user)
+	`, realm, realm, host, from, user, url, client_id, client_secret, scope)
 }
 
 func testKeycloakRealm_WithOTP(realm, otpType, algorithm string, period int, codeReusable bool) string {

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -123,12 +123,12 @@ func TestAccKeycloakRealm_SmtpServer(t *testing.T) {
 		CheckDestroy:             testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost.com", "admin@myhost.com", "user"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user"),
+				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost.com", "admin@myhost.com", "user", "password"),
+				Check:  testAccCheckKeycloakRealmSmtpPassword("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user", "password"),
 			},
 			{
 				Config: testKeycloakRealm_basic(realm, realm, realmDisplayNameHtml),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "", "", ""),
+				Check:  testAccCheckKeycloakRealmSmtpPassword("keycloak_realm.realm", "", "", "", ""),
 			},
 		},
 	})
@@ -143,12 +143,12 @@ func TestAccKeycloakRealm_SmtpServerUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost.com", "admin@myhost.com", "user"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user"),
+				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost.com", "admin@myhost.com", "user", "password"),
+				Check:  testAccCheckKeycloakRealmSmtpPassword("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user", "password"),
 			},
 			{
-				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost2.com", "admin@myhost2.com", "user2"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost2.com", "admin@myhost2.com", "user2"),
+				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost2.com", "admin@myhost2.com", "user2", "password2"),
+				Check:  testAccCheckKeycloakRealmSmtpPassword("keycloak_realm.realm", "myhost2.com", "admin@myhost2.com", "user2", "password2"),
 			},
 		},
 	})
@@ -1221,7 +1221,7 @@ func testAccCheckKeycloakRealmDisplayNameHtml(resourceName string, displayNameHt
 	}
 }
 
-func testAccCheckKeycloakRealmSmtp(resourceName, host, from, user string) resource.TestCheckFunc {
+func testAccCheckKeycloakRealmSmtpPassword(resourceName, host, from, user, password string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		realm, err := getRealmFromState(s, resourceName)
 		if err != nil {
@@ -1239,6 +1239,15 @@ func testAccCheckKeycloakRealmSmtp(resourceName, host, from, user string) resour
 		if realm.SmtpServer.User != user {
 			return fmt.Errorf("expected realm %s to have smtp user set to %s, but was %s", realm.Realm, user, realm.SmtpServer.User)
 		}
+
+		if realm.SmtpServer.Password != password {
+			return fmt.Errorf("expected realm %s to have smtp password set to %s, but was %s", realm.Realm, password, realm.SmtpServer.Password)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckKeycloakRealmSmtpOauth(resourceName, host, from, user, url, client_id, client_secret, scope string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		realm, err := getRealmFromState(s, resourceName)
@@ -1515,7 +1524,7 @@ resource "keycloak_realm" "realm" {
 	`, realm, realmDisplayName, realmDisplayNameHtml)
 }
 
-func testKeycloakRealm_WithSmtpServer(realm, host, from, user string) string {
+func testKeycloakRealm_WithSmtpServer(realm, host, from, user, password string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
 	realm = "%s"
@@ -1533,11 +1542,11 @@ resource "keycloak_realm" "realm" {
 		envelope_from = "nottom@myhost.com"
 		auth {
 			username = "%s"
-			password = "tom"
+			password = "%s"
 		}
 	}
 }
-	`, realm, realm, host, from, user)
+	`, realm, realm, host, from, user, password)
 }
 
 func testKeycloakRealm_WithSmtpServerWithOauth(realm, host, from, user, url, client_id, client_secret, scope string) string {

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -191,12 +191,12 @@ func TestAccKeycloakRealm_SmtpServerOauth(t *testing.T) {
 		CheckDestroy:             testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost.com", "admin@myhost.com", "user"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user"),
+				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble", "wiggle"),
+				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble", "wiggle"),
 			},
 			{
 				Config: testKeycloakRealm_basic(realm, realm, realmDisplayNameHtml),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "", "", ""),
+				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "", "", "", "", "", "", ""),
 			},
 		},
 	})
@@ -211,12 +211,12 @@ func TestAccKeycloakRealm_SmtpServerOauthUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost.com", "admin@myhost.com", "user"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user"),
+				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble", "wiggle"),
+				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble", "wiggle"),
 			},
 			{
-				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost2.com", "admin@myhost2.com", "user2"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost2.com", "admin@myhost2.com", "user2"),
+				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost2.com", "admin@myhost2.com", "user2", "wibble2.com", "wibble2", "wobble2", "wiggle2"),
+				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "myhost2.com", "admin@myhost2.com", "user2", "wibble2.com", "wibble2", "wobble2", "wiggle2"),
 			},
 		},
 	})
@@ -1424,6 +1424,40 @@ func testAccCheckKeycloakRealmSmtp(resourceName, host, from, user string) resour
 		if realm.SmtpServer.User != user {
 			return fmt.Errorf("expected realm %s to have smtp user set to %s, but was %s", realm.Realm, user, realm.SmtpServer.User)
 		}
+func testAccCheckKeycloakRealmSmtpOauth(resourceName, host, from, user, url, client_id, client_secret, scope string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		realm, err := getRealmFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if realm.SmtpServer.Host != host {
+			return fmt.Errorf("expected realm %s to have smtp host set to %s, but was %s", realm.Realm, host, realm.SmtpServer.Host)
+		}
+
+		if realm.SmtpServer.From != from {
+			return fmt.Errorf("expected realm %s to have smtp from set to %s, but was %s", realm.Realm, from, realm.SmtpServer.From)
+		}
+
+		if realm.SmtpServer.User != user {
+			return fmt.Errorf("expected realm %s to have smtp user set to %s, but was %s", realm.Realm, user, realm.SmtpServer.User)
+		}
+
+		if realm.SmtpServer.AuthTokenUrl != url {
+			return fmt.Errorf("expected realm %s to have smtp url set to %s, but was %s", realm.Realm, url, realm.SmtpServer.AuthTokenUrl)
+		}
+
+		if realm.SmtpServer.AuthTokenClientId != client_id {
+			return fmt.Errorf("expected realm %s to have smtp client id set to %s, but was %s", realm.Realm, client_id, realm.SmtpServer.AuthTokenClientId)
+		}
+
+		if realm.SmtpServer.AuthTokenClientSecret != client_secret {
+			return fmt.Errorf("expected realm %s to have smtp client secret set to %s, but was %s", realm.Realm, client_secret, realm.SmtpServer.AuthTokenClientSecret)
+		}
+
+		if realm.SmtpServer.AuthTokenScope != scope {
+			return fmt.Errorf("expected realm %s to have smtp scope set to %s, but was %s", realm.Realm, scope, realm.SmtpServer.AuthTokenScope)
+		}
 
 		return nil
 	}
@@ -1737,7 +1771,7 @@ resource "keycloak_realm" "realm" {
 	`, realm, realm, host, from, user)
 }
 
-func testKeycloakRealm_WithSmtpServerWithOauth(realm, host, from, user string) string {
+func testKeycloakRealm_WithSmtpServerWithOauth(realm, host, from, user, url, client_id, client_secret, scope string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
 	realm = "%s"
@@ -1755,14 +1789,14 @@ resource "keycloak_realm" "realm" {
 		envelope_from = "nottom@myhost.com"
 		token_auth {
 			username      = "%s"
-			url           = "wibble.com"
-			client_id     = "wibble"
-			client_secret = "wobble"
-			scope         = "wiggle"
+			url           = "%s"
+			client_id     = "%s"
+			client_secret = "%s"
+			scope         = "%s"
 		}
 	}
 }
-	`, realm, realm, host, from, user)
+	`, realm, realm, host, from, user, url, client_id, client_secret, scope)
 }
 
 func testKeycloakRealm_WithOTP(realm, otpType, algorithm string, period int, codeReusable bool) string {

--- a/provider/resource_keycloak_realm_test.go
+++ b/provider/resource_keycloak_realm_test.go
@@ -125,12 +125,12 @@ func TestAccKeycloakRealm_SmtpServer(t *testing.T) {
 		CheckDestroy:             testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost.com", "admin@myhost.com", "user"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user"),
+				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost.com", "admin@myhost.com", "user", "password"),
+				Check:  testAccCheckKeycloakRealmSmtpPassword("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user", "password"),
 			},
 			{
 				Config: testKeycloakRealm_basic(realm, realm, realmDisplayNameHtml),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "", "", ""),
+				Check:  testAccCheckKeycloakRealmSmtpPassword("keycloak_realm.realm", "", "", "", ""),
 			},
 		},
 	})
@@ -145,12 +145,12 @@ func TestAccKeycloakRealm_SmtpServerUpdate(t *testing.T) {
 		CheckDestroy:             testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost.com", "admin@myhost.com", "user"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user"),
+				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost.com", "admin@myhost.com", "user", "password"),
+				Check:  testAccCheckKeycloakRealmSmtpPassword("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user", "password"),
 			},
 			{
-				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost2.com", "admin@myhost2.com", "user2"),
-				Check:  testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost2.com", "admin@myhost2.com", "user2"),
+				Config: testKeycloakRealm_WithSmtpServer(realm, "myhost2.com", "admin@myhost2.com", "user2", "password2"),
+				Check:  testAccCheckKeycloakRealmSmtpPassword("keycloak_realm.realm", "myhost2.com", "admin@myhost2.com", "user2", "password2"),
 			},
 		},
 	})
@@ -164,16 +164,16 @@ func TestAccKeycloakRealm_SmtpServerAllowUtf8(t *testing.T) {
 		CheckDestroy:             testAccCheckKeycloakRealmDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testKeycloakRealm_WithSmtpServerAllowUtf8(realm, "myhost.com", "tom@myhost.com", "user"),
+				Config: testKeycloakRealm_WithSmtpServerAllowUtf8(realm, "myhost.com", "tom@myhost.com", "user", "password"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost.com", "tom@myhost.com", "user"),
+					testAccCheckKeycloakRealmSmtpPassword("keycloak_realm.realm", "myhost.com", "tom@myhost.com", "user", "password"),
 					resource.TestCheckResourceAttr("keycloak_realm.realm", "smtp_server.0.allow_utf8", "true"),
 				),
 			},
 			{
-				Config: testKeycloakRealm_WithSmtpServerAllowUtf8(realm, "myhost2.com", "tom@myhost2.com", "user2"),
+				Config: testKeycloakRealm_WithSmtpServerAllowUtf8(realm, "myhost2.com", "tom@myhost2.com", "user2", "password"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKeycloakRealmSmtp("keycloak_realm.realm", "myhost2.com", "tom@myhost2.com", "user2"),
+					testAccCheckKeycloakRealmSmtpPassword("keycloak_realm.realm", "myhost2.com", "tom@myhost2.com", "user2", "password"),
 					resource.TestCheckResourceAttr("keycloak_realm.realm", "smtp_server.0.allow_utf8", "true"),
 				),
 			},
@@ -215,8 +215,8 @@ func TestAccKeycloakRealm_SmtpServerOauthUpdate(t *testing.T) {
 				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble", "wiggle"),
 			},
 			{
-				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost2.com", "admin@myhost2.com", "user2", "wibble2.com", "wibble2", "wobble2", "wiggle2"),
-				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "myhost2.com", "admin@myhost2.com", "user2", "wibble2.com", "wibble2", "wobble2", "wiggle2"),
+				Config: testKeycloakRealm_WithSmtpServerWithOauth(realm, "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble2", "wiggle"),
+				Check:  testAccCheckKeycloakRealmSmtpOauth("keycloak_realm.realm", "myhost.com", "admin@myhost.com", "user", "wibble.com", "wibble", "wobble2", "wiggle"),
 			},
 		},
 	})
@@ -1406,7 +1406,7 @@ func testAccCheckKeycloakRealmDisplayNameHtml(resourceName string, displayNameHt
 	}
 }
 
-func testAccCheckKeycloakRealmSmtp(resourceName, host, from, user string) resource.TestCheckFunc {
+func testAccCheckKeycloakRealmSmtpPassword(resourceName, host, from, user, password string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		realm, err := getRealmFromState(s, resourceName)
 		if err != nil {
@@ -1424,6 +1424,21 @@ func testAccCheckKeycloakRealmSmtp(resourceName, host, from, user string) resour
 		if realm.SmtpServer.User != user {
 			return fmt.Errorf("expected realm %s to have smtp user set to %s, but was %s", realm.Realm, user, realm.SmtpServer.User)
 		}
+
+		if password == "" {
+			if err := resource.TestCheckNoResourceAttr(resourceName, "smtp_server.0.auth.0.password")(s); err != nil {
+				return fmt.Errorf("expected realm %s to have smtp password cleared in state: %w", realm.Realm, err)
+			}
+		} else {
+			if err := resource.TestCheckResourceAttr(resourceName, "smtp_server.0.auth.0.password", password)(s); err != nil {
+				return fmt.Errorf("expected realm %s to have smtp password set to %s in state: %w", realm.Realm, password, err)
+			}
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckKeycloakRealmSmtpOauth(resourceName, host, from, user, url, client_id, client_secret, scope string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		realm, err := getRealmFromState(s, resourceName)
@@ -1451,8 +1466,14 @@ func testAccCheckKeycloakRealmSmtpOauth(resourceName, host, from, user, url, cli
 			return fmt.Errorf("expected realm %s to have smtp client id set to %s, but was %s", realm.Realm, client_id, realm.SmtpServer.AuthTokenClientId)
 		}
 
-		if realm.SmtpServer.AuthTokenClientSecret != client_secret {
-			return fmt.Errorf("expected realm %s to have smtp client secret set to %s, but was %s", realm.Realm, client_secret, realm.SmtpServer.AuthTokenClientSecret)
+		if client_secret == "" {
+			if err := resource.TestCheckNoResourceAttr(resourceName, "smtp_server.0.token_auth.0.client_secret")(s); err != nil {
+				return fmt.Errorf("expected realm %s to have smtp client secret cleared in state: %w", realm.Realm, err)
+			}
+		} else {
+			if err := resource.TestCheckResourceAttr(resourceName, "smtp_server.0.token_auth.0.client_secret", client_secret)(s); err != nil {
+				return fmt.Errorf("expected realm %s to have smtp client secret set to %s in state: %w", realm.Realm, client_secret, err)
+			}
 		}
 
 		if realm.SmtpServer.AuthTokenScope != scope {
@@ -1720,7 +1741,7 @@ resource "keycloak_realm" "realm" {
 	`, realm, realmDisplayName, realmDisplayNameHtml)
 }
 
-func testKeycloakRealm_WithSmtpServer(realm, host, from, user string) string {
+func testKeycloakRealm_WithSmtpServer(realm, host, from, user, password string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
 	realm = "%s"
@@ -1738,14 +1759,14 @@ resource "keycloak_realm" "realm" {
 		envelope_from = "nottom@myhost.com"
 		auth {
 			username = "%s"
-			password = "tom"
+			password = "%s"
 		}
 	}
 }
-	`, realm, realm, host, from, user)
+	`, realm, realm, host, from, user, password)
 }
 
-func testKeycloakRealm_WithSmtpServerAllowUtf8(realm, host, from, user string) string {
+func testKeycloakRealm_WithSmtpServerAllowUtf8(realm, host, from, user, password string) string {
 	return fmt.Sprintf(`
 resource "keycloak_realm" "realm" {
 	realm = "%s"
@@ -1764,11 +1785,11 @@ resource "keycloak_realm" "realm" {
 		envelope_from = "nottom@%[3]s"
 		auth {
 			username = "%[5]s"
-			password = "tom"
+			password = "%[6]s"
 		}
 	}
 }
-	`, realm, realm, host, from, user)
+	`, realm, realm, host, from, user, password)
 }
 
 func testKeycloakRealm_WithSmtpServerWithOauth(realm, host, from, user, url, client_id, client_secret, scope string) string {


### PR DESCRIPTION
This patch bring the token_auth in line with auth wherein the provider gets the client secret from state rather than comparing against the Keycloak API response as it's always just a string of asterisks

Fixes #1577