### PR TITLE
feat: new keycloak_user_password resource

### DIFF
--- a/docs/resources/user_password.md
+++ b/docs/resources/user_password.md
@@ -1,0 +1,58 @@
+---
+page_title: "keycloak_user_password Resource"
+---
+
+# keycloak\_user\_password Resource
+
+Manages a user's password credential in Keycloak. This resource is separate from `keycloak_user` so that password
+changes can be planned and applied independently of the user resource.
+
+~> When the user managed by `keycloak_user` is created without `initial_password`, Keycloak automatically
+sets `required_actions = ["UPDATE_PASSWORD"]` on the user. Applying a `keycloak_user_password` clears this
+required action, causing a permanent diff on the `keycloak_user` resource. To avoid this, either set
+`initial_password` on the `keycloak_user` resource, or add `lifecycle { ignore_changes = [required_actions] }`
+to the `keycloak_user` resource.
+
+The password value is write-only: it is never stored in Terraform state and never appears in plan output. Change
+detection is handled by comparing a SHA-512 hash of the configured value with a hash stored in state.
+
+## Example Usage
+
+```hcl
+data "keycloak_realm" "realm" {
+  realm = "my-realm"
+}
+
+resource "keycloak_user" "user" {
+  realm_id = data.keycloak_realm.realm.id
+  username = "alice"
+}
+
+resource "keycloak_user_password" "user_password" {
+  realm_id = data.keycloak_realm.realm.id
+  user_id  = keycloak_user.user.id
+  value    = "some password"
+}
+```
+
+## Argument Reference
+
+- `realm_id` - (Required) The realm the user belongs to.
+- `user_id` - (Required) The ID of the user to manage the password for.
+- `value` - (Required, write-only) The password value. This value is sensitive and is not stored in state or shown in plan output.
+- `temporary` - (Optional) If set to `true`, the password is set as temporary and the user will be prompted to change it on first login. Defaults to `false`.
+
+## Attribute Reference
+
+- `value_hash` - A SHA-512 digest of the currently applied password, used internally to detect when `value` changes across Terraform runs.
+- `credential_id` - The UUID of the Keycloak password credential. Used internally to detect out-of-band password resets.
+
+## Import
+
+User passwords can be imported using the format `{{realm_id}}/{{user_id}}`. The `value` attribute cannot be recovered from the API and must be supplied in the configuration after import.
+
+Example:
+
+```bash
+$ terraform import keycloak_user_password.user_password my-realm/60c3f971-b1d3-4b3a-9035-d16d7540a5e4
+```

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
+	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
 )
 
@@ -48,7 +49,6 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/zclconf/go-cty v1.18.1 // indirect
-	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/keycloak/user.go
+++ b/keycloak/user.go
@@ -247,3 +247,35 @@ func (keycloakClient *KeycloakClient) RemoveUserFromGroups(ctx context.Context, 
 	}
 	return nil
 }
+
+type UserCredential struct {
+	Id          string `json:"id,omitempty"`
+	Type        string `json:"type,omitempty"`
+	CreatedDate int64  `json:"createdDate,omitempty"`
+	Temporary   *bool  `json:"temporary,omitempty"`
+	// additional fields omitted
+}
+
+// GetUserPasswordCredential fetches the list of credentials for a user and
+// returns the one with type "password", or nil if no password credential exists.
+func (keycloakClient *KeycloakClient) GetUserPasswordCredential(ctx context.Context, realmId, userId string) (*UserCredential, error) {
+	var credentials []*UserCredential
+
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/users/%s/credentials", realmId, userId), &credentials, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cred := range credentials {
+		if cred.Type == "password" {
+			return cred, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// DeleteUserCredential removes a specific credential from a user.
+func (keycloakClient *KeycloakClient) DeleteUserCredential(ctx context.Context, realmId, userId, credentialId string) error {
+	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/users/%s/credentials/%s", realmId, userId, credentialId), nil)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -59,6 +59,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 			"keycloak_default_roles":                                     resourceKeycloakDefaultRoles(),
 			"keycloak_group_roles":                                       resourceKeycloakGroupRoles(),
 			"keycloak_user":                                              resourceKeycloakUser(),
+			"keycloak_user_password":                                     resourceKeycloakUserPassword(),
 			"keycloak_user_roles":                                        resourceKeycloakUserRoles(),
 			"keycloak_openid_client":                                     resourceKeycloakOpenidClient(),
 			"keycloak_openid_client_scope":                               resourceKeycloakOpenidClientScope(),

--- a/provider/resource_keycloak_user_password.go
+++ b/provider/resource_keycloak_user_password.go
@@ -1,0 +1,267 @@
+package provider
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+	"golang.org/x/crypto/argon2"
+)
+
+func resourceKeycloakUserPassword() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKeycloakUserPasswordCreate,
+		ReadContext:   resourceKeycloakUserPasswordRead,
+		UpdateContext: resourceKeycloakUserPasswordUpdate,
+		DeleteContext: resourceKeycloakUserPasswordDelete,
+		CustomizeDiff: resourceKeycloakUserPasswordDiff,
+		// This resource can be imported using {{realm}}/{{userId}}.
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakUserPasswordImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"user_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"value": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+				WriteOnly: true,
+			},
+			"temporary": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			// credential_id is the UUID of the Keycloak password credential.
+			// It changes every time reset-password is called, so it is used
+			// to track remote state.
+			"credential_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			// value_hash stores a SHA-512 digest of the currently applied
+			// password so that the provider can detect changes to the
+			// WriteOnly value argument across Terraform runs.
+			"value_hash": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func hashValue(value string) string {
+	salt := []byte("terraform-provider-keycloak")
+	hash := argon2.IDKey([]byte(value), salt, 1, 64*1024, 4, 32)
+	return hex.EncodeToString(hash)
+}
+
+// resourceKeycloakUserPasswordDiff detects changes to the WriteOnly
+// value argument by comparing its digest with the value_hash
+// stored in state. When they differ, value_hash is set to the new hash,
+// producing a plan diff that triggers an update.
+func resourceKeycloakUserPasswordDiff(_ context.Context, d *schema.ResourceDiff, _ interface{}) error {
+	raw := d.GetRawConfig()
+	val := raw.GetAttr("value")
+	if val.IsNull() {
+		return nil
+	}
+
+	newHash := hashValue(val.AsString())
+	oldHash := d.Get("value_hash").(string)
+
+	if oldHash != newHash {
+		d.SetNew("value_hash", newHash)
+	}
+
+	return nil
+}
+
+// getPasswordValue returns the password value from the raw config
+// since value is WriteOnly and cannot be read from state.
+func getPasswordValue(data *schema.ResourceData) (string, diag.Diagnostics) {
+	raw, d := data.GetRawConfigAt(cty.GetAttrPath("value"))
+	if d.HasError() {
+		return "", d
+	}
+	if raw.IsNull() {
+		return "", diag.Errorf("value must be set")
+	}
+	return raw.AsString(), nil
+}
+
+func resourceKeycloakUserPasswordId(realmId, userId string) string {
+	return fmt.Sprintf("%s/%s", realmId, userId)
+}
+
+// setCredentialState fetches the current password credential after a
+// reset-password call and writes credential_id and value_hash into state.
+func setCredentialState(ctx context.Context, data *schema.ResourceData, keycloakClient *keycloak.KeycloakClient, value string) error {
+	realmId := data.Get("realm_id").(string)
+	userId := data.Get("user_id").(string)
+
+	cred, err := keycloakClient.GetUserPasswordCredential(ctx, realmId, userId)
+	if err != nil {
+		return err
+	}
+	if cred == nil {
+		return fmt.Errorf("password credential not found for user %s in realm %s after reset", userId, realmId)
+	}
+
+	data.Set("credential_id", cred.Id)
+	data.Set("value_hash", hashValue(value))
+	return nil
+}
+
+func resourceKeycloakUserPasswordCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	userId := data.Get("user_id").(string)
+	temporary := data.Get("temporary").(bool)
+
+	value, valueDiags := getPasswordValue(data)
+	if valueDiags.HasError() {
+		return valueDiags
+	}
+
+	if err := keycloakClient.ResetUserPassword(ctx, realmId, userId, value, temporary); err != nil {
+		return diag.FromErr(err)
+	}
+
+	data.SetId(resourceKeycloakUserPasswordId(realmId, userId))
+
+	if err := setCredentialState(ctx, data, keycloakClient, value); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceKeycloakUserPasswordRead(ctx, data, meta)
+}
+
+// resourceKeycloakUserPasswordRead checks whether the password credential
+// still exists and whether it has been reset out-of-band.
+//
+// Because reset-password always produces a brand-new credential ID, a change
+// in credential_id is the reliable signal that someone reset the password
+// outside Terraform.  When that happens we clear the resource ID so Terraform
+// will plan a new apply of the configured value.
+func resourceKeycloakUserPasswordRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	userId := data.Get("user_id").(string)
+
+	cred, err := keycloakClient.GetUserPasswordCredential(ctx, realmId, userId)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	// Credential was deleted outside Terraform — remove from state.
+	if cred == nil {
+		data.SetId("")
+		return nil
+	}
+
+	storedCredentialId := data.Get("credential_id").(string)
+
+	// credential_id changed → password was reset out-of-band.
+	// Clear state so Terraform plans a re-apply of the configured value.
+	if storedCredentialId != "" && cred.Id != storedCredentialId {
+		data.SetId("")
+		return nil
+	}
+
+	data.Set("credential_id", cred.Id)
+	if cred.Temporary != nil {
+		data.Set("temporary", *cred.Temporary)
+	}
+
+	return nil
+}
+
+func resourceKeycloakUserPasswordUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	userId := data.Get("user_id").(string)
+	temporary := data.Get("temporary").(bool)
+
+	value, valueDiags := getPasswordValue(data)
+	if valueDiags.HasError() {
+		return valueDiags
+	}
+
+	if err := keycloakClient.ResetUserPassword(ctx, realmId, userId, value, temporary); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := setCredentialState(ctx, data, keycloakClient, value); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceKeycloakUserPasswordRead(ctx, data, meta)
+}
+
+// resourceKeycloakUserPasswordDelete removes the password credential from
+// Keycloak using the stored credential_id.
+func resourceKeycloakUserPasswordDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	userId := data.Get("user_id").(string)
+	credentialId := data.Get("credential_id").(string)
+
+	if credentialId == "" {
+		return nil
+	}
+
+	return diag.FromErr(keycloakClient.DeleteUserCredential(ctx, realmId, userId, credentialId))
+}
+
+func resourceKeycloakUserPasswordImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid import. Supported import format: {{realmId}}/{{userId}}")
+	}
+
+	realmId := parts[0]
+	userId := parts[1]
+
+	if _, err := keycloakClient.GetUser(ctx, realmId, userId); err != nil {
+		return nil, err
+	}
+
+	cred, err := keycloakClient.GetUserPasswordCredential(ctx, realmId, userId)
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("realm_id", realmId)
+	d.Set("user_id", userId)
+	d.SetId(resourceKeycloakUserPasswordId(realmId, userId))
+
+	if cred != nil {
+		d.Set("credential_id", cred.Id)
+	}
+	// value and value_hash cannot be recovered from the API;
+	// callers must supply value after import or accept a plan
+	// diff on next apply.
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/provider/resource_keycloak_user_password_test.go
+++ b/provider/resource_keycloak_user_password_test.go
@@ -1,0 +1,198 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestAccKeycloakUserPassword_basic(t *testing.T) {
+	username := acctest.RandomWithPrefix("tf-acc")
+	password := acctest.RandomWithPrefix("tf-acc")
+	clientId := acctest.RandomWithPrefix("tf-acc")
+
+	resourceName := "keycloak_user_password.user_password"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakUserDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakUserPassword_basic(username, password, clientId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakUserPasswordExists(resourceName),
+					testAccCheckKeycloakUserInitialPasswordLogin(username, password, clientId),
+					resource.TestCheckResourceAttr(resourceName, "temporary", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakUserPassword_update(t *testing.T) {
+	username := acctest.RandomWithPrefix("tf-acc")
+	passwordOne := acctest.RandomWithPrefix("tf-acc")
+	passwordTwo := acctest.RandomWithPrefix("tf-acc")
+	clientId := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakUserDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakUserPassword_basic(username, passwordOne, clientId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakUserInitialPasswordLogin(username, passwordOne, clientId),
+				),
+			},
+			{
+				Config: testKeycloakUserPassword_basic(username, passwordTwo, clientId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakUserInitialPasswordLogin(username, passwordTwo, clientId),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakUserPassword_temporary(t *testing.T) {
+	username := acctest.RandomWithPrefix("tf-acc")
+	password := acctest.RandomWithPrefix("tf-acc")
+
+	resourceName := "keycloak_user_password.user_password"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakUserDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:             testKeycloakUserPassword_temporary(username, password),
+				ExpectNonEmptyPlan: true,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakUserPasswordExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "temporary", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakUserPassword_import(t *testing.T) {
+	username := acctest.RandomWithPrefix("tf-acc")
+	password := acctest.RandomWithPrefix("tf-acc")
+	clientId := acctest.RandomWithPrefix("tf-acc")
+
+	resourceName := "keycloak_user_password.user_password"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakUserDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakUserPassword_basic(username, password, clientId),
+				Check:  testAccCheckKeycloakUserPasswordExists(resourceName),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"value", "value_hash", "temporary"},
+				ImportStateIdFunc:       testAccKeycloakUserPasswordImportId(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckKeycloakUserPasswordExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		realmId := rs.Primary.Attributes["realm_id"]
+		userId := rs.Primary.Attributes["user_id"]
+
+		if _, err := keycloakClient.GetUser(testCtx, realmId, userId); err != nil {
+			return fmt.Errorf("error fetching user %s in realm %s: %s", userId, realmId, err)
+		}
+
+		return nil
+	}
+}
+
+func testAccKeycloakUserPasswordImportId(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		realmId := rs.Primary.Attributes["realm_id"]
+		userId := rs.Primary.Attributes["user_id"]
+
+		return fmt.Sprintf("%s/%s", realmId, userId), nil
+	}
+}
+
+func testKeycloakUserPassword_basic(username, password, clientId string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "client" {
+	realm_id                     = data.keycloak_realm.realm.id
+	client_id                    = "%s"
+	name                         = "test client"
+	enabled                      = true
+	access_type                  = "PUBLIC"
+	direct_access_grants_enabled = true
+}
+
+resource "keycloak_user" "user" {
+	realm_id   = data.keycloak_realm.realm.id
+	username   = "%s"
+	email      = "%s@test.local"
+	first_name = "Test"
+	last_name  = "User"
+}
+
+resource "keycloak_user_password" "user_password" {
+	realm_id  = data.keycloak_realm.realm.id
+	user_id   = keycloak_user.user.id
+	value     = "%s"
+	temporary = false
+}
+`, testAccRealm.Realm, clientId, username, username, password)
+}
+
+func testKeycloakUserPassword_temporary(username, password string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_user" "user" {
+	realm_id   = data.keycloak_realm.realm.id
+	username   = "%s"
+	email      = "%s@test.local"
+	first_name = "Test"
+	last_name  = "User"
+}
+
+resource "keycloak_user_password" "user_password" {
+	realm_id  = data.keycloak_realm.realm.id
+	user_id   = keycloak_user.user.id
+	value     = "%s"
+	temporary = true
+}
+`, testAccRealm.Realm, username, username, password)
+}


### PR DESCRIPTION
Closes #1545
Add a keycloak_user_password resource. See `user_password.md‎` for more information.

I choose to use WriteOnly in a transparent manner (without adding `_wo` and `_wo_version` to the API, both approaches are valid and [documented](https://developer.hashicorp.com/terraform/plugin/framework/resources/write-only-arguments#best-practices)).