### PR TITLE
fix(openid-client): prevent stale client_secret in state from overwriting client_secret_wo

### DIFF
--- a/provider/resource_keycloak_openid_client.go
+++ b/provider/resource_keycloak_openid_client.go
@@ -484,6 +484,10 @@ func getOpenidClientFromData(data *schema.ResourceData) (*keycloak.OpenidClient,
 		}
 
 		openidClient.ClientSecret = clientSecretWriteOnly.AsString()
+	} else if data.Get("client_secret_wo_version").(int) != 0 {
+		// write-only mode, version unchanged: discard any stale client_secret from state
+		// so it is not sent to Keycloak and does not overwrite the existing secret
+		openidClient.ClientSecret = ""
 	}
 
 	if !openidClient.ImplicitFlowEnabled && !openidClient.StandardFlowEnabled {

--- a/provider/resource_keycloak_openid_client_test.go
+++ b/provider/resource_keycloak_openid_client_test.go
@@ -2107,7 +2107,7 @@ resource "keycloak_openid_client" "client" {
 	access_type              = "CONFIDENTIAL"
 	name                     = "%s"
 	client_secret_wo         = "%s"
-	client_secret_wo_version = "%d"
+	client_secret_wo_version = %d
 }
 	`, testAccRealm.Realm, clientId, name, clientSecretWriteOnly, clientSecretWriteOnlyVersion)
 }

--- a/provider/resource_keycloak_openid_client_test.go
+++ b/provider/resource_keycloak_openid_client_test.go
@@ -496,6 +496,104 @@ func TestAccKeycloakOpenidClient_secretWriteOnly(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakOpenidClient_secretWriteOnlyNotClearedAfterExplicitSwitch(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+	clientSecretExplicit := acctest.RandomWithPrefix("tf-acc")
+	clientSecretWO := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakOpenidClientDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// step 1: create with an explicit client_secret; value lands in Terraform state
+				Config: testKeycloakOpenidClient_secret(clientId, clientSecretExplicit),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidClientExistsWithCorrectProtocol("keycloak_openid_client.client"),
+					testAccCheckKeycloakOpenidClientHasClientSecret("keycloak_openid_client.client", clientSecretExplicit),
+				),
+			},
+			{
+				// step 2: switch to write-only; version changes 0→1 so new secret is applied;
+				// the stale explicit secret remains in state (setOpenidClientData does not clear it)
+				// — this is the precondition for the bug this test guards against
+				Config: testKeycloakOpenidClient_secretWriteOnly(clientId, clientSecretWO, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidClientHasClientSecret("keycloak_openid_client.client", clientSecretWO),
+					resource.TestCheckResourceAttr("keycloak_openid_client.client", "client_secret_wo_version", "1"),
+				),
+			},
+			{
+				// step 3: update an unrelated field, version unchanged — stale explicit secret
+				// in state must NOT overwrite the write-only secret in Keycloak
+				Config: testKeycloakOpenidClient_secretWriteOnlyWithName(clientId, clientSecretWO, 1, clientId+"-named"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidClientHasClientSecret("keycloak_openid_client.client", clientSecretWO),
+				),
+			},
+			{
+				// step 4: re-apply same config — plan must be empty (no secret drift after migration)
+				Config:             testKeycloakOpenidClient_secretWriteOnlyWithName(clientId, clientSecretWO, 1, clientId+"-named"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccKeycloakOpenidClient_secretWriteOnlyComputedSecretNoDrift covers the case where a
+// CONFIDENTIAL client was created without an explicit client_secret. Keycloak generates a
+// secret automatically and the provider stores it as a computed value in state. When the user
+// later switches to client_secret_wo (no explicit client_secret ever in config), that computed
+// Keycloak-generated secret must not overwrite the write-only secret on subsequent applies.
+func TestAccKeycloakOpenidClient_secretWriteOnlyComputedSecretNoDrift(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+	clientSecretWO := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakOpenidClientDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// step 1: CONFIDENTIAL client, no explicit client_secret in config
+				// Keycloak generates a secret; provider stores it as computed client_secret in state
+				Config: testKeycloakOpenidClient_basic(clientId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidClientExistsWithCorrectProtocol("keycloak_openid_client.client"),
+					resource.TestCheckResourceAttrSet("keycloak_openid_client.client", "client_secret"),
+				),
+			},
+			{
+				// step 2: switch to write-only; version 0→1 so new secret is applied
+				// the Keycloak-generated computed secret remains in state (never cleared by provider)
+				Config: testKeycloakOpenidClient_secretWriteOnly(clientId, clientSecretWO, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidClientHasClientSecret("keycloak_openid_client.client", clientSecretWO),
+					resource.TestCheckResourceAttr("keycloak_openid_client.client", "client_secret_wo_version", "1"),
+				),
+			},
+			{
+				// step 3: change extra_config only; version unchanged
+				// stale computed client_secret in state must NOT overwrite the write-only secret
+				Config: testKeycloakOpenidClient_secretWriteOnlyWithExtraConfig(clientId, clientSecretWO, 1, map[string]string{"key1": "value1"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOpenidClientHasClientSecret("keycloak_openid_client.client", clientSecretWO),
+				),
+			},
+			{
+				// step 4: re-apply same config — plan must be empty (no secret drift)
+				Config:             testKeycloakOpenidClient_secretWriteOnlyWithExtraConfig(clientId, clientSecretWO, 1, map[string]string{"key1": "value1"}),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccKeycloakOpenidClient_redirectUrisValidation(t *testing.T) {
 	t.Parallel()
 	clientId := acctest.RandomWithPrefix("tf-acc")
@@ -1995,6 +2093,49 @@ resource "keycloak_openid_client" "client" {
 	client_secret_wo_version = "%d"
 }
 	`, testAccRealm.Realm, clientId, clientSecretWriteOnly, clientSecretWriteOnlyVersion)
+}
+
+func testKeycloakOpenidClient_secretWriteOnlyWithName(clientId, clientSecretWriteOnly string, clientSecretWriteOnlyVersion int, name string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "client" {
+	client_id                = "%s"
+	realm_id                 = data.keycloak_realm.realm.id
+	access_type              = "CONFIDENTIAL"
+	name                     = "%s"
+	client_secret_wo         = "%s"
+	client_secret_wo_version = "%d"
+}
+	`, testAccRealm.Realm, clientId, name, clientSecretWriteOnly, clientSecretWriteOnlyVersion)
+}
+
+func testKeycloakOpenidClient_secretWriteOnlyWithExtraConfig(clientId, clientSecretWriteOnly string, clientSecretWriteOnlyVersion int, extraConfig map[string]string) string {
+	var extraConfigBlock string
+	if len(extraConfig) > 0 {
+		var sb strings.Builder
+		sb.WriteString("\textra_config = {\n")
+		for k, v := range extraConfig {
+			sb.WriteString(fmt.Sprintf("\t\t\"%s\" = \"%s\"\n", k, v))
+		}
+		sb.WriteString("\t}\n")
+		extraConfigBlock = sb.String()
+	}
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "client" {
+	client_id                = "%s"
+	realm_id                 = data.keycloak_realm.realm.id
+	access_type              = "CONFIDENTIAL"
+	client_secret_wo         = "%s"
+	client_secret_wo_version = %d
+%s}
+	`, testAccRealm.Realm, clientId, clientSecretWriteOnly, clientSecretWriteOnlyVersion, extraConfigBlock)
 }
 
 func testKeycloakOpenidClient_invalidRedirectUris(clientId, accessType string, standardFlowEnabled, implicitFlowEnabled bool) string {


### PR DESCRIPTION
client_secret is Computed: true, so Terraform always stores a value for it — either one the user explicitly set, or the secret Keycloak generated automatically for a CONFIDENTIAL client. This means every client that ever existed without an explicit client_secret still carries the Keycloak-generated value in state.

The typical real-world pattern is: an existing CONFIDENTIAL client (possibly managed via random_password or without any secret config at all) is migrated to client_secret_wo. The old computed client_secret remains in state because setOpenidClientData never clears it when write-only mode is active. On any subsequent apply where client_secret_wo_version is unchanged —  an unrelated attribute change, a drift correction, anything — getOpenidClientFromData reads the stale value via data.Get("client_secret") and includes it in the PUT body, silently overwriting the active write-only secret with the old one.

Fix: add an else-if branch to the write-only block in getOpenidClientFromData. When the write-only version is non-zero but unchanged (i.e. the version-gate intentionally skips the secret update), explicitly zero out ClientSecret. Because OpenidClient is marshalled with encoding/json and ClientSecret carries the omitempty tag, the empty value is omitted from the PUT body entirely, leaving Keycloak's current secret untouched.

Three acceptance tests cover the fix:
- explicit client_secret migrated to write-only, then unrelated change
- CONFIDENTIAL client with no explicit secret (computed value in state) migrated to write-only, then unrelated extra_config change
- fresh write-only client, unrelated extra_config change, PlanOnly no-drift

Fixes #1602