### PR TITLE
fix: removes custom validation logic

### DIFF
--- a/provider/resource_keycloak_oidc_identity_provider.go
+++ b/provider/resource_keycloak_oidc_identity_provider.go
@@ -53,6 +53,7 @@ func resourceKeycloakOidcIdentityProvider() *schema.Resource {
 			Sensitive:     true,
 			Description:   "Client Secret.",
 			ConflictsWith: []string{"client_secret_wo", "client_secret_wo_version"},
+			AtLeastOneOf:  []string{"client_secret", "client_secret_wo"},
 		},
 		"client_secret_wo": {
 			Type:          schema.TypeString,
@@ -61,6 +62,7 @@ func resourceKeycloakOidcIdentityProvider() *schema.Resource {
 			WriteOnly:     true,
 			ConflictsWith: []string{"client_secret"},
 			RequiredWith:  []string{"client_secret_wo_version"},
+			AtLeastOneOf:  []string{"client_secret", "client_secret_wo"},
 			Description:   "Client Secret as write-only argument",
 		},
 		"client_secret_wo_version": {
@@ -142,10 +144,6 @@ func resourceKeycloakOidcIdentityProvider() *schema.Resource {
 	oidcResource.CreateContext = resourceKeycloakIdentityProviderCreate(getOidcIdentityProviderFromData, setOidcIdentityProviderData)
 	oidcResource.ReadContext = resourceKeycloakIdentityProviderRead(setOidcIdentityProviderData)
 	oidcResource.UpdateContext = resourceKeycloakIdentityProviderUpdate(getOidcIdentityProviderFromData, setOidcIdentityProviderData)
-	oidcResource.ValidateRawResourceConfigFuncs = []schema.ValidateRawResourceConfigFunc{
-		// validate that argument is required if none of the checkExists attributes exist
-		requiredWithoutAll(cty.GetAttrPath("client_secret"), []cty.Path{cty.GetAttrPath("client_secret_wo"), cty.GetAttrPath("client_secret_wo_version")}),
-	}
 	return oidcResource
 }
 

--- a/provider/resource_keycloak_oidc_identity_provider_test.go
+++ b/provider/resource_keycloak_oidc_identity_provider_test.go
@@ -264,6 +264,24 @@ func TestAccKeycloakOidcIdentityProvider_clientSecretWriteOnly(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakOidcIdentityProvider_clientSecretMissing(t *testing.T) {
+	t.Parallel()
+
+	oidcName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakOidcIdentityProviderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      testKeycloakOidcIdentityProvider_noClientSecret(oidcName),
+				ExpectError: regexp.MustCompile("Missing required argument"),
+			},
+		},
+	})
+}
+
 func testAccCheckKeycloakOidcIdentityProviderExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, err := getKeycloakOidcIdentityProviderFromState(s, resourceName)
@@ -550,4 +568,22 @@ resource "keycloak_oidc_identity_provider" "oidc" {
 	issuer = "hello"
 }
 	`, testAccRealm.Realm, oidc, clientSecretWriteOnly, clientSecretWriteOnlyVersion)
+}
+
+func testKeycloakOidcIdentityProvider_noClientSecret(oidc string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_oidc_identity_provider" "oidc" {
+	realm             = data.keycloak_realm.realm.id
+	alias             = "%s"
+	authorization_url = "https://example.com/auth"
+	token_url         = "https://example.com/token"
+	client_id         = "example_id"
+
+	issuer = "hello"
+}
+	`, testAccRealm.Realm, oidc)
 }

--- a/provider/utils.go
+++ b/provider/utils.go
@@ -2,12 +2,10 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -157,39 +155,4 @@ func suppressDiffWhenNotInConfig(attrName string) schema.SchemaDiffSuppressFunc 
 
 func intPointer(i int) *int {
 	return &i
-}
-
-// requiredWithoutAll returns a validator which checks that the attribute at `argument` exists
-// if none of the attributes in `checkExists` exist in the configuration
-func requiredWithoutAll(key cty.Path, checkExists []cty.Path) schema.ValidateRawResourceConfigFunc {
-	return func(ctx context.Context, req schema.ValidateResourceConfigFuncRequest, resp *schema.ValidateResourceConfigFuncResponse) {
-		// Skip validation for null or unknown values
-		if req.RawConfig.IsNull() || !req.RawConfig.IsKnown() {
-			return
-		}
-
-		// Check if any of the checkExists attributes exist
-		anyExists := false
-		for _, path := range checkExists {
-			val, err := path.Apply(req.RawConfig)
-			if err == nil && !val.IsNull() {
-				anyExists = true
-				break
-			}
-		}
-
-		// If any exist, the argument is not required
-		if anyExists {
-			return
-		}
-
-		val, err := key.Apply(req.RawConfig)
-		if err != nil || val.IsNull() {
-			resp.Diagnostics = append(resp.Diagnostics, diag.Diagnostic{
-				Severity: diag.Error,
-				Summary:  "Required attribute not set",
-				Detail:   fmt.Sprintf("The attribute %s is required when none of the following attributes are specified: %v", key, checkExists),
-			})
-		}
-	}
 }


### PR DESCRIPTION
The custom argument validation logic for `secret`, `secret_wo` and `secret_wo_version` fails when the arguments are not known at the time of evaluation. This happens when running `terraform validate` and the resource is used in a module that acquires their values through variables.

This uses native terraform keywords to define the fact that either `secret` or `secret_wo` is required and adds a test for this case.