### PR TITLE
feat: Add support for Keycloak organization groups

### DIFF
--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -35,13 +35,23 @@ resource "keycloak_group_roles" "group_roles" {
 }
 ```
 
+Organization groups can be looked up by setting `organization_id`. Organization groups require Keycloak 26.6.0 or later.
+
+```hcl
+data "keycloak_group" "organization_group" {
+    realm_id        = keycloak_realm.realm.id
+    organization_id = keycloak_organization.organization.id
+    name            = "organization-group"
+}
+```
+
 ## Argument Reference
 
 - `realm_id` - (Required) The realm this group exists within.
+- `organization_id` - (Optional) The organization this group exists within. If omitted, the data source looks up realm groups.
 - `name` - (Required) The name of the group. If there are multiple groups match `name`, the first result will be returned.
 
 ## Attributes Reference
 
 - `id` - (Computed) The unique ID of the group, which can be used as an argument to
   other resources supported by this provider.
-

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -44,9 +44,36 @@ resource "keycloak_group" "child_group_with_optional_attributes" {
 }
 ```
 
+Organization groups can be managed by setting `organization_id`. Organization groups require Keycloak 26.6.0 or later.
+
+```hcl
+resource "keycloak_organization" "organization" {
+  realm = keycloak_realm.realm.id
+  name  = "my-organization"
+
+  domain {
+    name = "example.com"
+  }
+}
+
+resource "keycloak_group" "organization_group" {
+  realm_id        = keycloak_realm.realm.id
+  organization_id = keycloak_organization.organization.id
+  name            = "organization-group"
+}
+
+resource "keycloak_group" "organization_child_group" {
+  realm_id        = keycloak_realm.realm.id
+  organization_id = keycloak_organization.organization.id
+  parent_id       = keycloak_group.organization_group.id
+  name            = "organization-child-group"
+}
+```
+
 ## Argument Reference
 
 - `realm_id` - (Required) The realm this group exists in.
+- `organization_id` - (Optional) The organization this group exists in. If omitted, this group will be managed as a realm group. Organization groups require Keycloak 26.6.0 or later.
 - `parent_id` - (Optional) The ID of this group's parent. If omitted, this group will be defined at the root level.
 - `name` - (Required) The name of the group.
 - `attributes` - (Optional) A map representing attributes for the group. In order to add multivalued attributes, use `##` to separate the values. Max length for each value is 255 chars
@@ -60,8 +87,11 @@ resource "keycloak_group" "child_group_with_optional_attributes" {
 Groups can be imported using the format `{{realm_id}}/{{group_id}}`, where `group_id` is the unique ID that Keycloak
 assigns to the group upon creation. This value can be found in the URI when editing this group in the GUI, and is typically a GUID.
 
+Organization groups can be imported using the format `{{realm_id}}/{{organization_id}}/{{group_id}}`.
+
 Example:
 
 ```bash
 $ terraform import keycloak_group.child_group my-realm/934a4a4e-28bd-4703-a0fa-332df153aabd
+$ terraform import keycloak_group.organization_group my-realm/9c9ef4b9-c4f2-4d17-ae03-0c6576df6c11/934a4a4e-28bd-4703-a0fa-332df153aabd
 ```

--- a/keycloak/group.go
+++ b/keycloak/group.go
@@ -67,8 +67,10 @@ func (keycloakClient *KeycloakClient) ValidateGroupMembers(usernames []interface
 }
 
 // NewGroup creates a new group based on the following rules:
-// Top level groups are created via POST /realms/${realm_id}/groups
-// Child groups are created via POST /realms/${realm_id}/groups/${parent_id}/children
+// Realm top-level groups are created via POST /realms/${realm_id}/groups.
+// Realm child groups are created via POST /realms/${realm_id}/groups/${parent_id}/children.
+// Organization top-level groups are created via POST /realms/${realm_id}/organizations/${organization_id}/groups.
+// Organization child groups are created via POST /realms/${realm_id}/organizations/${organization_id}/groups/${parent_id}/children.
 func (keycloakClient *KeycloakClient) NewGroup(ctx context.Context, group *Group) error {
 	var createGroupUrl string
 

--- a/keycloak/group.go
+++ b/keycloak/group.go
@@ -8,16 +8,17 @@ import (
 )
 
 type Group struct {
-	Id          string              `json:"id,omitempty"`
-	RealmId     string              `json:"-"`
-	ParentId    string              `json:"-"`
-	Name        string              `json:"name"`
-	Description string              `json:"description,omitempty"`
-	Path        string              `json:"path,omitempty"`
-	SubGroups   []*Group            `json:"subGroups,omitempty"`
-	RealmRoles  []string            `json:"realmRoles,omitempty"`
-	ClientRoles map[string][]string `json:"clientRoles,omitempty"`
-	Attributes  map[string][]string `json:"attributes"`
+	Id             string              `json:"id,omitempty"`
+	RealmId        string              `json:"-"`
+	ParentId       string              `json:"-"`
+	OrganizationId string              `json:"-"`
+	Name           string              `json:"name"`
+	Description    string              `json:"description,omitempty"`
+	Path           string              `json:"path,omitempty"`
+	SubGroups      []*Group            `json:"subGroups,omitempty"`
+	RealmRoles     []string            `json:"realmRoles,omitempty"`
+	ClientRoles    map[string][]string `json:"clientRoles,omitempty"`
+	Attributes     map[string][]string `json:"attributes"`
 }
 
 /*
@@ -40,7 +41,14 @@ func (keycloakClient *KeycloakClient) groupParentId(ctx context.Context, group *
 
 	var parentGroup Group
 
-	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/group-by-path/%s", group.RealmId, encodedPath), &parentGroup, nil)
+	var groupByPathUrl string
+	if group.OrganizationId != "" {
+		groupByPathUrl = fmt.Sprintf("/realms/%s/organizations/%s/groups/group-by-path/%s", group.RealmId, group.OrganizationId, encodedPath)
+	} else {
+		groupByPathUrl = fmt.Sprintf("/realms/%s/group-by-path/%s", group.RealmId, encodedPath)
+	}
+
+	err := keycloakClient.get(ctx, groupByPathUrl, &parentGroup, nil)
 	if err != nil {
 		return "", err
 	}
@@ -64,10 +72,18 @@ func (keycloakClient *KeycloakClient) ValidateGroupMembers(usernames []interface
 func (keycloakClient *KeycloakClient) NewGroup(ctx context.Context, group *Group) error {
 	var createGroupUrl string
 
-	if group.ParentId == "" {
-		createGroupUrl = fmt.Sprintf("/realms/%s/groups", group.RealmId)
+	if group.OrganizationId != "" {
+		if group.ParentId == "" {
+			createGroupUrl = fmt.Sprintf("/realms/%s/organizations/%s/groups", group.RealmId, group.OrganizationId)
+		} else {
+			createGroupUrl = fmt.Sprintf("/realms/%s/organizations/%s/groups/%s/children", group.RealmId, group.OrganizationId, group.ParentId)
+		}
 	} else {
-		createGroupUrl = fmt.Sprintf("/realms/%s/groups/%s/children", group.RealmId, group.ParentId)
+		if group.ParentId == "" {
+			createGroupUrl = fmt.Sprintf("/realms/%s/groups", group.RealmId)
+		} else {
+			createGroupUrl = fmt.Sprintf("/realms/%s/groups/%s/children", group.RealmId, group.ParentId)
+		}
 	}
 
 	_, location, err := keycloakClient.post(ctx, createGroupUrl, group)
@@ -96,14 +112,26 @@ func (keycloakClient *KeycloakClient) GetGroups(ctx context.Context, realmId str
 }
 
 func (keycloakClient *KeycloakClient) GetGroup(ctx context.Context, realmId, id string) (*Group, error) {
+	return keycloakClient.GetOrganizationGroup(ctx, realmId, "", id)
+}
+
+func (keycloakClient *KeycloakClient) GetOrganizationGroup(ctx context.Context, realmId, organizationId, id string) (*Group, error) {
 	var group Group
 
-	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/groups/%s", realmId, id), &group, nil)
+	var getGroupUrl string
+	if organizationId != "" {
+		getGroupUrl = fmt.Sprintf("/realms/%s/organizations/%s/groups/%s", realmId, organizationId, id)
+	} else {
+		getGroupUrl = fmt.Sprintf("/realms/%s/groups/%s", realmId, id)
+	}
+
+	err := keycloakClient.get(ctx, getGroupUrl, &group, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	group.RealmId = realmId // it's important to set RealmId here because fetching the ParentId depends on it
+	group.OrganizationId = organizationId
 
 	parentId, err := keycloakClient.groupParentId(ctx, &group)
 	if err != nil {
@@ -116,6 +144,10 @@ func (keycloakClient *KeycloakClient) GetGroup(ctx context.Context, realmId, id 
 }
 
 func (keycloakClient *KeycloakClient) GetGroupByName(ctx context.Context, realmId, name string) (*Group, error) {
+	return keycloakClient.GetOrganizationGroupByName(ctx, realmId, "", name)
+}
+
+func (keycloakClient *KeycloakClient) GetOrganizationGroupByName(ctx context.Context, realmId, organizationId, name string) (*Group, error) {
 	var groups []Group
 
 	// We can't get a group by name, so we have to search for it
@@ -123,7 +155,14 @@ func (keycloakClient *KeycloakClient) GetGroupByName(ctx context.Context, realmI
 		"search": name,
 	}
 
-	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/groups", realmId), &groups, params)
+	var getGroupsUrl string
+	if organizationId != "" {
+		getGroupsUrl = fmt.Sprintf("/realms/%s/organizations/%s/groups", realmId, organizationId)
+	} else {
+		getGroupsUrl = fmt.Sprintf("/realms/%s/groups", realmId)
+	}
+
+	err := keycloakClient.get(ctx, getGroupsUrl, &groups, params)
 	if err != nil {
 		return nil, err
 	}
@@ -140,6 +179,7 @@ func (keycloakClient *KeycloakClient) GetGroupByName(ctx context.Context, realmI
 	group := getGroupByDFS(name, groupsPtr)
 	if group != nil {
 		group.RealmId = realmId // it's important to set RealmId here because fetching the ParentId depends on it
+		group.OrganizationId = organizationId
 
 		parentId, err := keycloakClient.groupParentId(ctx, group)
 		if err != nil {
@@ -172,11 +212,27 @@ func getGroupByDFS(groupName string, groups []*Group) *Group {
 }
 
 func (keycloakClient *KeycloakClient) UpdateGroup(ctx context.Context, group *Group) error {
-	return keycloakClient.put(ctx, fmt.Sprintf("/realms/%s/groups/%s", group.RealmId, group.Id), group)
+	var updateGroupUrl string
+	if group.OrganizationId != "" {
+		updateGroupUrl = fmt.Sprintf("/realms/%s/organizations/%s/groups/%s", group.RealmId, group.OrganizationId, group.Id)
+	} else {
+		updateGroupUrl = fmt.Sprintf("/realms/%s/groups/%s", group.RealmId, group.Id)
+	}
+	return keycloakClient.put(ctx, updateGroupUrl, group)
 }
 
 func (keycloakClient *KeycloakClient) DeleteGroup(ctx context.Context, realmId, id string) error {
-	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/groups/%s", realmId, id), nil)
+	return keycloakClient.DeleteOrganizationGroup(ctx, realmId, "", id)
+}
+
+func (keycloakClient *KeycloakClient) DeleteOrganizationGroup(ctx context.Context, realmId, organizationId, id string) error {
+	var deleteGroupUrl string
+	if organizationId != "" {
+		deleteGroupUrl = fmt.Sprintf("/realms/%s/organizations/%s/groups/%s", realmId, organizationId, id)
+	} else {
+		deleteGroupUrl = fmt.Sprintf("/realms/%s/groups/%s", realmId, id)
+	}
+	return keycloakClient.delete(ctx, deleteGroupUrl, nil)
 }
 
 func (keycloakClient *KeycloakClient) ListGroupsWithName(ctx context.Context, realmId, name string) ([]*Group, error) {

--- a/provider/data_source_keycloak_group.go
+++ b/provider/data_source_keycloak_group.go
@@ -16,6 +16,10 @@ func dataSourceKeycloakGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"organization_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -44,9 +48,10 @@ func dataSourceKeycloakGroupRead(ctx context.Context, data *schema.ResourceData,
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
 	realmId := data.Get("realm_id").(string)
+	organizationId := data.Get("organization_id").(string)
 	groupName := data.Get("name").(string)
 
-	group, err := keycloakClient.GetGroupByName(ctx, realmId, groupName)
+	group, err := keycloakClient.GetOrganizationGroupByName(ctx, realmId, organizationId, groupName)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/provider/data_source_keycloak_group_test.go
+++ b/provider/data_source_keycloak_group_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
 )
 
 func TestAccKeycloakDataSourceGroup_basic(t *testing.T) {
@@ -65,6 +66,33 @@ func TestAccKeycloakDataSourceGroup_nested(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakDataSourceGroup_basicWithOrganization(t *testing.T) {
+	skipIfVersionIsLessThan(testCtx, t, keycloakClient, keycloak.Version_26_6)
+	t.Parallel()
+
+	organizationName := acctest.RandomWithPrefix("tf-acc")
+	group := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakGroupDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceKeycloakGroup_basicWithOrganization(organizationName, group),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakGroupExistsWithOrganization("keycloak_group.group"),
+					resource.TestCheckResourceAttrPair("keycloak_group.group", "id", "data.keycloak_group.group", "id"),
+					resource.TestCheckResourceAttrPair("keycloak_group.group", "realm_id", "data.keycloak_group.group", "realm_id"),
+					resource.TestCheckResourceAttrPair("keycloak_group.group", "organization_id", "data.keycloak_group.group", "organization_id"),
+					resource.TestCheckResourceAttrPair("keycloak_group.group", "name", "data.keycloak_group.group", "name"),
+					testAccCheckDataKeycloakGroup("data.keycloak_group.group"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDataKeycloakGroup(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -74,9 +102,10 @@ func testAccCheckDataKeycloakGroup(resourceName string) resource.TestCheckFunc {
 
 		id := rs.Primary.ID
 		realmId := rs.Primary.Attributes["realm_id"]
+		organizationId := rs.Primary.Attributes["organization_id"]
 		name := rs.Primary.Attributes["name"]
 
-		group, err := keycloakClient.GetGroup(testCtx, realmId, id)
+		group, err := keycloakClient.GetOrganizationGroup(testCtx, realmId, organizationId, id)
 		if err != nil {
 			return err
 		}
@@ -116,6 +145,45 @@ data "keycloak_group" "group" {
 	]
 }
 	`, testAccRealm.Realm, group, group)
+}
+
+func testDataSourceKeycloakGroup_basicWithOrganization(organization, group string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_organization" "organization" {
+	name  = "%s"
+	realm = data.keycloak_realm.realm.id
+
+	domain {
+		name = "%s.example.com"
+	}
+}
+
+resource "keycloak_group" "group" {
+	name            = "%s"
+	realm_id        = data.keycloak_realm.realm.id
+	organization_id = keycloak_organization.organization.id
+}
+
+resource "keycloak_group" "realm_group_with_same_name" {
+	name     = "%s"
+	realm_id = data.keycloak_realm.realm.id
+}
+
+data "keycloak_group" "group" {
+	realm_id        = data.keycloak_realm.realm.id
+	organization_id = keycloak_organization.organization.id
+	name            = keycloak_group.group.name
+
+	depends_on = [
+		keycloak_group.group,
+		keycloak_group.realm_group_with_same_name,
+	]
+}
+	`, testAccRealm.Realm, organization, organization, group, group)
 }
 
 func TestAccKeycloakDataSourceGroup_nestedWithSpaces(t *testing.T) {

--- a/provider/resource_keycloak_group.go
+++ b/provider/resource_keycloak_group.go
@@ -27,6 +27,11 @@ func resourceKeycloakGroup() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"organization_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 			"parent_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -67,11 +72,12 @@ func mapFromDataToGroup(data *schema.ResourceData) *keycloak.Group {
 	description, descriptionOk := data.GetOkExists("description")
 
 	group := &keycloak.Group{
-		Id:         data.Id(),
-		RealmId:    data.Get("realm_id").(string),
-		ParentId:   data.Get("parent_id").(string),
-		Name:       data.Get("name").(string),
-		Attributes: attributes,
+		Id:             data.Id(),
+		RealmId:        data.Get("realm_id").(string),
+		ParentId:       data.Get("parent_id").(string),
+		OrganizationId: data.Get("organization_id").(string),
+		Name:           data.Get("name").(string),
+		Attributes:     attributes,
 	}
 
 	// Set description only if explicitly provided, preserving empty strings
@@ -89,6 +95,7 @@ func mapFromGroupToData(data *schema.ResourceData, group *keycloak.Group) {
 	}
 	data.SetId(group.Id)
 	data.Set("realm_id", group.RealmId)
+	data.Set("organization_id", group.OrganizationId)
 	data.Set("name", group.Name)
 	data.Set("description", group.Description)
 	data.Set("path", group.Path)
@@ -121,9 +128,10 @@ func resourceKeycloakGroupRead(ctx context.Context, data *schema.ResourceData, m
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
 	realmId := data.Get("realm_id").(string)
+	organizationId := data.Get("organization_id").(string)
 	id := data.Id()
 
-	group, err := keycloakClient.GetGroup(ctx, realmId, id)
+	group, err := keycloakClient.GetOrganizationGroup(ctx, realmId, organizationId, id)
 	if err != nil {
 		return handleNotFoundError(ctx, err, data)
 	}
@@ -156,26 +164,36 @@ func resourceKeycloakGroupDelete(ctx context.Context, data *schema.ResourceData,
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
 	realmId := data.Get("realm_id").(string)
+	organizationId := data.Get("organization_id").(string)
 	id := data.Id()
 
-	return diag.FromErr(keycloakClient.DeleteGroup(ctx, realmId, id))
+	return diag.FromErr(keycloakClient.DeleteOrganizationGroup(ctx, realmId, organizationId, id))
 }
 
 func resourceKeycloakGroupImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
 	parts := strings.Split(d.Id(), "/")
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("Invalid import. Supported import formats: {{realmId}}/{{groupId}}")
+	if len(parts) != 2 && len(parts) != 3 {
+		return nil, fmt.Errorf("Invalid import. Supported import formats: {{realmId}}/{{groupId}} or {{realmId}}/{{organizationId}}/{{groupId}}")
 	}
 
-	_, err := keycloakClient.GetGroup(ctx, parts[0], parts[1])
+	realmId := parts[0]
+	groupId := parts[1]
+	organizationId := ""
+	if len(parts) == 3 {
+		organizationId = parts[1]
+		groupId = parts[2]
+	}
+
+	_, err := keycloakClient.GetOrganizationGroup(ctx, realmId, organizationId, groupId)
 	if err != nil {
 		return nil, err
 	}
 
-	d.Set("realm_id", parts[0])
-	d.SetId(parts[1])
+	d.Set("realm_id", realmId)
+	d.Set("organization_id", organizationId)
+	d.SetId(groupId)
 
 	diagnostics := resourceKeycloakGroupRead(ctx, d, meta)
 	if diagnostics.HasError() {

--- a/provider/resource_keycloak_group_test.go
+++ b/provider/resource_keycloak_group_test.go
@@ -51,6 +51,76 @@ func runTestBasicGroup(t *testing.T, groupName, attributeName, attributeValue st
 	})
 }
 
+func TestAccKeycloakGroup_basicWithOrganization(t *testing.T) {
+	skipIfVersionIsLessThan(testCtx, t, keycloakClient, keycloak.Version_26_6)
+	t.Parallel()
+
+	organizationName := acctest.RandomWithPrefix("tf-acc")
+	groupName := acctest.RandomWithPrefix("tf-acc/")
+	attributeName := acctest.RandomWithPrefix("tf-acc")
+	attributeValue := acctest.RandomWithPrefix("tf-acc")
+
+	runTestBasicGroupWithOrganization(t, organizationName, groupName, attributeName, attributeValue)
+}
+
+func TestAccKeycloakGroup_nestedWithOrganization(t *testing.T) {
+	skipIfVersionIsLessThan(testCtx, t, keycloakClient, keycloak.Version_26_6)
+	t.Parallel()
+
+	organizationName := acctest.RandomWithPrefix("tf-acc")
+	parentGroupName := acctest.RandomWithPrefix("tf-acc/")
+	childGroupName := acctest.RandomWithPrefix("tf-acc/")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakGroupDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakGroup_nestedWithOrganization(organizationName, parentGroupName, childGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakGroupExistsWithOrganization("keycloak_group.parent_group"),
+					testAccCheckKeycloakGroupExistsWithOrganization("keycloak_group.child_group"),
+					resource.TestCheckResourceAttrPair("keycloak_group.child_group", "parent_id", "keycloak_group.parent_group", "id"),
+					resource.TestCheckResourceAttrPair("keycloak_group.child_group", "organization_id", "keycloak_organization.organization", "id"),
+				),
+			},
+			{
+				ResourceName:      "keycloak_group.parent_group",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getGroupWithOrganizationImportId("keycloak_group.parent_group"),
+			},
+			{
+				ResourceName:      "keycloak_group.child_group",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getGroupWithOrganizationImportId("keycloak_group.child_group"),
+			},
+		},
+	})
+}
+
+func runTestBasicGroupWithOrganization(t *testing.T, organizationName, groupName, attributeName, attributeValue string) {
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakGroupDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakGroup_basicWithOrganization(organizationName, groupName, attributeName, attributeValue),
+				Check:  testAccCheckKeycloakGroupExistsWithOrganization("keycloak_group.group"),
+			},
+			{
+				ResourceName:      "keycloak_group.group",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getGroupWithOrganizationImportId("keycloak_group.group"),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakGroup_createAfterManualDestroy(t *testing.T) {
 	t.Parallel()
 
@@ -360,6 +430,17 @@ func testAccCheckKeycloakGroupExists(resourceName string) resource.TestCheckFunc
 	}
 }
 
+func testAccCheckKeycloakGroupExistsWithOrganization(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, err := getGroupFromStateWithOrganization(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckKeycloakGroupFetch(resourceName string, group *keycloak.Group) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		fetchedGroup, err := getGroupFromState(s, resourceName)
@@ -398,8 +479,9 @@ func testAccCheckKeycloakGroupDestroy() resource.TestCheckFunc {
 
 			id := rs.Primary.ID
 			realm := rs.Primary.Attributes["realm_id"]
+			organizationId := rs.Primary.Attributes["organization_id"]
 
-			group, _ := keycloakClient.GetGroup(testCtx, realm, id)
+			group, _ := keycloakClient.GetOrganizationGroup(testCtx, realm, organizationId, id)
 			if group != nil {
 				return fmt.Errorf("group with id %s still exists", id)
 			}
@@ -426,6 +508,39 @@ func getGroupFromState(s *terraform.State, resourceName string) (*keycloak.Group
 	return group, nil
 }
 
+func getGroupFromStateWithOrganization(s *terraform.State, resourceName string) (*keycloak.Group, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("resource not found: %s", resourceName)
+	}
+
+	id := rs.Primary.ID
+	realm := rs.Primary.Attributes["realm_id"]
+	organizationId := rs.Primary.Attributes["organization_id"]
+
+	group, err := keycloakClient.GetOrganizationGroup(testCtx, realm, organizationId, id)
+	if err != nil {
+		return nil, fmt.Errorf("error getting group with id %s: %s", id, err)
+	}
+
+	return group, nil
+}
+
+func getGroupWithOrganizationImportId(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		realm := rs.Primary.Attributes["realm_id"]
+		organizationId := rs.Primary.Attributes["organization_id"]
+		groupId := rs.Primary.ID
+
+		return fmt.Sprintf("%s/%s/%s", realm, organizationId, groupId), nil
+	}
+}
+
 func testKeycloakGroup_basic(group string, attributeName string, attributeValue string) string {
 	return fmt.Sprintf(`
 data "keycloak_realm" "realm" {
@@ -440,6 +555,62 @@ resource "keycloak_group" "group" {
 	}
 }
 	`, testAccRealm.Realm, strings.ReplaceAll(group, "\\", "\\\\"), attributeName, attributeValue)
+}
+
+func testKeycloakGroup_basicWithOrganization(organization, group string, attributeName string, attributeValue string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_organization" "organization" {
+	name  = "%s"
+	realm = data.keycloak_realm.realm.id
+
+	domain {
+		name = "%s.example.com"
+	}
+}
+
+resource "keycloak_group" "group" {
+	name     = "%s"
+	realm_id = data.keycloak_realm.realm.id
+	organization_id = keycloak_organization.organization.id
+	attributes = {
+		"%s" = "%s"
+	}
+}
+	`, testAccRealm.Realm, organization, organization, strings.ReplaceAll(group, "\\", "\\\\"), attributeName, attributeValue)
+}
+
+func testKeycloakGroup_nestedWithOrganization(organization, parentGroup, childGroup string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_organization" "organization" {
+	name  = "%s"
+	realm = data.keycloak_realm.realm.id
+
+	domain {
+		name = "%s.example.com"
+	}
+}
+
+resource "keycloak_group" "parent_group" {
+	name            = "%s"
+	realm_id        = data.keycloak_realm.realm.id
+	organization_id = keycloak_organization.organization.id
+}
+
+resource "keycloak_group" "child_group" {
+	name            = "%s"
+	realm_id        = data.keycloak_realm.realm.id
+	organization_id = keycloak_organization.organization.id
+	parent_id       = keycloak_group.parent_group.id
+}
+	`, testAccRealm.Realm, organization, organization, strings.ReplaceAll(parentGroup, "\\", "\\\\"), strings.ReplaceAll(childGroup, "\\", "\\\\"))
 }
 
 func testKeycloakGroup_updateRealmBefore(group string) string {


### PR DESCRIPTION
## Summary

Adds support for managing Keycloak organization groups through `keycloak_group`.

This includes:
- `organization_id` support on the `keycloak_group` resource
- create, read, update, delete, and import support for organization groups
- nested organization group support via `parent_id`
- `organization_id` support on the `keycloak_group` data source
- acceptance tests for resource and data source behavior
- documentation updates for resource usage, data source usage, and import format

Organization groups require Keycloak 26.6.0 or later.

`GetGroup` is kept as the existing realm-group API for backwards compatibility. It now delegates to `GetOrganizationGroup` with an empty organization ID, so existing callers keep working while organization-scoped callers can use the new Keycloak organization group endpoint.

Fixes #1561