### PR TITLE
feat: add "add_to_userinfo" and "add_to_token_introspection" to user session note mapper

### DIFF
--- a/docs/resources/openid_user_session_note_protocol_mapper.md
+++ b/docs/resources/openid_user_session_note_protocol_mapper.md
@@ -77,8 +77,8 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 - `claim_value_type` - (Optional) The claim type used when serializing JSON tokens. Can be one of `String`, `JSON`, `long`, `int`, or `boolean`. Defaults to `String`.
 - `session_note` - (Optional) String value being the name of stored user session note within the `UserSessionModel.note` map.
 - `session_note_label` - (Optional) **Deprecated** Use `session_note` instead.
-- `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
-- `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.
+- `add_to_id_token` - (Optional) Indicates if the session note should be added as a claim to the id token. Defaults to `true`.
+- `add_to_access_token` - (Optional) Indicates if the session note should be added as a claim to the access token. Defaults to `true`.
 - `add_to_userinfo` - (Optional) Indicates if the session note should be added as a claim to the UserInfo response body. Defaults to `true`.
 - `add_to_token_introspection` - (Optional) Indicates if the session note should be added as a claim to the token introspection response. Defaults to `true`.
 

--- a/docs/resources/openid_user_session_note_protocol_mapper.md
+++ b/docs/resources/openid_user_session_note_protocol_mapper.md
@@ -79,6 +79,8 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 - `session_note_label` - (Optional) **Deprecated** Use `session_note` instead.
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.
+- `add_to_userinfo` - (Optional) Indicates if the property should be added as a claim to the UserInfo response body. Defaults to `true`.
+- `add_to_token_introspection` - (Optional) Indicates if the property should be added as a claim to the token introspection response. Defaults to `true`.
 
 ## Import
 

--- a/docs/resources/openid_user_session_note_protocol_mapper.md
+++ b/docs/resources/openid_user_session_note_protocol_mapper.md
@@ -79,8 +79,8 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 - `session_note_label` - (Optional) **Deprecated** Use `session_note` instead.
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.
-- `add_to_userinfo` - (Optional) Indicates if the property should be added as a claim to the UserInfo response body. Defaults to `true`.
-- `add_to_token_introspection` - (Optional) Indicates if the property should be added as a claim to the token introspection response. Defaults to `true`.
+- `add_to_userinfo` - (Optional) Indicates if the session note should be added as a claim to the UserInfo response body. Defaults to `true`.
+- `add_to_token_introspection` - (Optional) Indicates if the session note should be added as a claim to the token introspection response. Defaults to `true`.
 
 ## Import
 

--- a/keycloak/openid_user_session_note_protocol_mapper.go
+++ b/keycloak/openid_user_session_note_protocol_mapper.go
@@ -13,8 +13,10 @@ type OpenIdUserSessionNoteProtocolMapper struct {
 	ClientId      string
 	ClientScopeId string
 
-	AddToIdToken     bool
-	AddToAccessToken bool
+	AddToIdToken            bool
+	AddToAccessToken        bool
+	AddToUserInfo           bool
+	AddToTokenIntrospection bool
 
 	ClaimName       string
 	ClaimValueType  string
@@ -28,11 +30,13 @@ func (mapper *OpenIdUserSessionNoteProtocolMapper) convertToGenericProtocolMappe
 		Protocol:       "openid-connect",
 		ProtocolMapper: "oidc-usersessionmodel-note-mapper",
 		Config: map[string]string{
-			addToIdTokenField:     strconv.FormatBool(mapper.AddToIdToken),
-			addToAccessTokenField: strconv.FormatBool(mapper.AddToAccessToken),
-			claimNameField:        mapper.ClaimName,
-			claimValueTypeField:   mapper.ClaimValueType,
-			userSessionNoteField:  mapper.UserSessionNote,
+			addToIdTokenField:            strconv.FormatBool(mapper.AddToIdToken),
+			addToAccessTokenField:        strconv.FormatBool(mapper.AddToAccessToken),
+			addToUserInfoField:           strconv.FormatBool(mapper.AddToUserInfo),
+			addToTokenIntrospectionField: strconv.FormatBool(mapper.AddToTokenIntrospection),
+			claimNameField:               mapper.ClaimName,
+			claimValueTypeField:          mapper.ClaimValueType,
+			userSessionNoteField:         mapper.UserSessionNote,
 		},
 	}
 }
@@ -48,6 +52,16 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserSessionNoteProtocolMapp
 		return nil, err
 	}
 
+	addToUserInfo, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToUserInfoField])
+	if err != nil {
+		return nil, err
+	}
+
+	addToTokenIntrospection, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToTokenIntrospectionField])
+	if err != nil {
+		return nil, err
+	}
+
 	return &OpenIdUserSessionNoteProtocolMapper{
 		Id:            protocolMapper.Id,
 		Name:          protocolMapper.Name,
@@ -55,8 +69,10 @@ func (protocolMapper *protocolMapper) convertToOpenIdUserSessionNoteProtocolMapp
 		ClientId:      clientId,
 		ClientScopeId: clientScopeId,
 
-		AddToIdToken:     addToIdToken,
-		AddToAccessToken: addToAccessToken,
+		AddToIdToken:            addToIdToken,
+		AddToAccessToken:        addToAccessToken,
+		AddToUserInfo:           addToUserInfo,
+		AddToTokenIntrospection: addToTokenIntrospection,
 
 		ClaimName:       protocolMapper.Config[claimNameField],
 		ClaimValueType:  protocolMapper.Config[claimValueTypeField],

--- a/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
@@ -64,13 +64,13 @@ func resourceKeycloakOpenIdUserSessionNoteProtocolMapper() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Indicates if the attribute should appear in the userinfo response body.",
+				Description: "Indicates if the session note should appear in the userinfo response body.",
 			},
 			"add_to_token_introspection": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Indicates if the attribute should be a claim in the token introspection response.",
+				Description: "Indicates if the session note should be a claim in the token introspection response.",
 			},
 			"claim_name": {
 				Type:     schema.TypeString,

--- a/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_session_note_protocol_mapper.go
@@ -60,6 +60,18 @@ func resourceKeycloakOpenIdUserSessionNoteProtocolMapper() *schema.Resource {
 				Default:     true,
 				Description: "Indicates if the attribute should be a claim in the access token.",
 			},
+			"add_to_userinfo": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Indicates if the attribute should appear in the userinfo response body.",
+			},
+			"add_to_token_introspection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Indicates if the attribute should be a claim in the token introspection response.",
+			},
 			"claim_name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -82,13 +94,15 @@ func resourceKeycloakOpenIdUserSessionNoteProtocolMapper() *schema.Resource {
 
 func mapFromDataToOpenIdUserSessionNoteProtocolMapper(data *schema.ResourceData) *keycloak.OpenIdUserSessionNoteProtocolMapper {
 	return &keycloak.OpenIdUserSessionNoteProtocolMapper{
-		Id:               data.Id(),
-		Name:             data.Get("name").(string),
-		RealmId:          data.Get("realm_id").(string),
-		ClientId:         data.Get("client_id").(string),
-		ClientScopeId:    data.Get("client_scope_id").(string),
-		AddToIdToken:     data.Get("add_to_id_token").(bool),
-		AddToAccessToken: data.Get("add_to_access_token").(bool),
+		Id:                      data.Id(),
+		Name:                    data.Get("name").(string),
+		RealmId:                 data.Get("realm_id").(string),
+		ClientId:                data.Get("client_id").(string),
+		ClientScopeId:           data.Get("client_scope_id").(string),
+		AddToIdToken:            data.Get("add_to_id_token").(bool),
+		AddToAccessToken:        data.Get("add_to_access_token").(bool),
+		AddToUserInfo:           data.Get("add_to_userinfo").(bool),
+		AddToTokenIntrospection: data.Get("add_to_token_introspection").(bool),
 
 		ClaimName:       data.Get("claim_name").(string),
 		ClaimValueType:  data.Get("claim_value_type").(string),
@@ -109,6 +123,8 @@ func mapFromOpenIdUserSessionNoteMapperToData(mapper *keycloak.OpenIdUserSession
 
 	data.Set("add_to_id_token", mapper.AddToIdToken)
 	data.Set("add_to_access_token", mapper.AddToAccessToken)
+	data.Set("add_to_userinfo", mapper.AddToUserInfo)
+	data.Set("add_to_token_introspection", mapper.AddToTokenIntrospection)
 	data.Set("claim_name", mapper.ClaimName)
 	data.Set("claim_value_type", mapper.ClaimValueType)
 	data.Set("session_note", mapper.UserSessionNote)

--- a/provider/resource_keycloak_openid_user_session_note_protocol_mapper_test.go
+++ b/provider/resource_keycloak_openid_user_session_note_protocol_mapper_test.go
@@ -142,6 +142,38 @@ func TestAccKeycloakOpenIdUserSessionNoteProtocolMapper_updateNote(t *testing.T)
 	})
 }
 
+func TestAccKeycloakOpenIdUserSessionNoteProtocolMapper_updateAddToUserinfoAndTokenIntrospection(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+	mapperName := acctest.RandomWithPrefix("tf-acc")
+
+	resourceName := "keycloak_openid_user_session_note_protocol_mapper.user_session_note_mapper"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccKeycloakOpenIdUserSessionNoteProtocolMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenIdUserSessionNoteProtocolMapper_addToUserinfoAndTokenIntrospection(clientId, mapperName, false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakOpenIdUserSessionNoteProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_to_userinfo", "false"),
+					resource.TestCheckResourceAttr(resourceName, "add_to_token_introspection", "false"),
+				),
+			},
+			{
+				Config: testKeycloakOpenIdUserSessionNoteProtocolMapper_addToUserinfoAndTokenIntrospection(clientId, mapperName, true, true),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakOpenIdUserSessionNoteProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_to_userinfo", "true"),
+					resource.TestCheckResourceAttr(resourceName, "add_to_token_introspection", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakOpenIdUserSessionNoteProtocolMapper_createAfterManualDestroy(t *testing.T) {
 	t.Parallel()
 	var mapper = &keycloak.OpenIdUserSessionNoteProtocolMapper{}
@@ -402,6 +434,28 @@ resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_
 	claim_value_type   = "String"
 	session_note       = "%s"
 }`, testAccRealm.Realm, clientId, mapperName, noteName)
+}
+
+func testKeycloakOpenIdUserSessionNoteProtocolMapper_addToUserinfoAndTokenIntrospection(clientId, mapperName string, addToUserinfo, addToTokenIntrospection bool) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+resource "keycloak_openid_client" "openid_client" {
+	realm_id  = data.keycloak_realm.realm.id
+	client_id = "%s"
+	access_type = "BEARER-ONLY"
+}
+resource "keycloak_openid_user_session_note_protocol_mapper" "user_session_note_mapper" {
+	name                       = "%s"
+	realm_id                   = data.keycloak_realm.realm.id
+	client_id                  = "${keycloak_openid_client.openid_client.id}"
+	claim_name                 = "foo"
+	claim_value_type           = "String"
+	session_note               = "bar"
+	add_to_userinfo            = %t
+	add_to_token_introspection = %t
+}`, testAccRealm.Realm, clientId, mapperName, addToUserinfo, addToTokenIntrospection)
 }
 
 func testKeycloakOpenIdUserSessionNoteProtocolMapper_import(clientId, clientScopeId, mapperName string) string {


### PR DESCRIPTION
Adds "add_to_userinfo" and "add_to_token_introspection" options to keycloak_openid_user_session_note_protocol_mapper resource similar to keycloak_openid_user_attribute_protocol_mapper mapper.
