### PR TITLE
feat: support import for realm default and optional client scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## What's Changed
 
+FEATURES:
+
+* feat: support import for `keycloak_realm_default_client_scopes` and `keycloak_realm_optional_client_scopes` using the realm id
+
 ## 5.8.0 (June 05, 2026)
 
 FEATURES:

--- a/docs/resources/realm_default_client_scopes.md
+++ b/docs/resources/realm_default_client_scopes.md
@@ -43,5 +43,13 @@ resource "keycloak_realm_default_client_scopes" "default_scopes" {
 
 ## Import
 
-This resource does not support import. Instead of importing, feel free to create this resource
-as if it did not already exist on the server.
+This resource can be imported using the realm id, which adopts the realm's current
+default client scopes into state. This is useful for reviewing the exact delta between
+a realm's existing (e.g. Keycloak factory) default scopes and your declared set in the
+plan, rather than starting from an opaque create.
+
+Example:
+
+```bash
+terraform import keycloak_realm_default_client_scopes.default_scopes my-realm
+```

--- a/docs/resources/realm_optional_client_scopes.md
+++ b/docs/resources/realm_optional_client_scopes.md
@@ -43,5 +43,13 @@ resource "keycloak_realm_optional_client_scopes" "optional_scopes" {
 
 ## Import
 
-This resource does not support import. Instead of importing, feel free to create this resource
-as if it did not already exist on the server.
+This resource can be imported using the realm id, which adopts the realm's current
+optional client scopes into state. This is useful for reviewing the exact delta between
+a realm's existing (e.g. Keycloak factory) optional scopes and your declared set in the
+plan, rather than starting from an opaque create.
+
+Example:
+
+```bash
+terraform import keycloak_realm_optional_client_scopes.optional_scopes my-realm
+```

--- a/provider/resource_keycloak_realm_default_client_scopes.go
+++ b/provider/resource_keycloak_realm_default_client_scopes.go
@@ -14,6 +14,10 @@ func resourceKeycloakRealmDefaultClientScopes() *schema.Resource {
 		ReadContext:   resourceKeycloakRealmDefaultClientScopesRead,
 		DeleteContext: resourceKeycloakRealmDefaultClientScopesDelete,
 		UpdateContext: resourceKeycloakRealmDefaultClientScopesReconcile,
+		Importer: &schema.ResourceImporter{
+			// Import id is the realm id (the resource id is the realm id too).
+			StateContext: resourceKeycloakRealmDefaultClientScopesImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"realm_id": {
 				Type:     schema.TypeString,
@@ -97,4 +101,14 @@ func resourceKeycloakRealmDefaultClientScopesDelete(ctx context.Context, data *s
 	defaultClientScopes := data.Get("default_scopes").(*schema.Set)
 
 	return diag.FromErr(keycloakClient.UnmarkClientScopesAsRealmDefault(ctx, realmId, interfaceSliceToStringSlice(defaultClientScopes.List())))
+}
+
+// resourceKeycloakRealmDefaultClientScopesImport adopts the realm-level default
+// client scopes into state. The import id is the realm id; realm_id is required
+// by the Read, so it is populated from the id before Read runs (which then
+// resolves the current default scopes and sets the resource id to the realm id).
+func resourceKeycloakRealmDefaultClientScopesImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("realm_id", d.Id())
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/provider/resource_keycloak_realm_default_client_scopes_test.go
+++ b/provider/resource_keycloak_realm_default_client_scopes_test.go
@@ -27,6 +27,18 @@ func TestAccKeycloakRealmDefaultClientScopes_basic(t *testing.T) {
 					"keycloak_realm_default_client_scopes.default_scopes",
 					[]string{"profile", "email", "web-origins", "roles", "role_list", clientScope}),
 			},
+			{
+				ResourceName:      "keycloak_realm_default_client_scopes.default_scopes",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["keycloak_realm_default_client_scopes.default_scopes"]
+					if !ok {
+						return "", fmt.Errorf("resource not found: keycloak_realm_default_client_scopes.default_scopes")
+					}
+					return rs.Primary.Attributes["realm_id"], nil
+				},
+			},
 		},
 	})
 }

--- a/provider/resource_keycloak_realm_optional_client_scopes.go
+++ b/provider/resource_keycloak_realm_optional_client_scopes.go
@@ -14,6 +14,10 @@ func resourceKeycloakRealmOptionalClientScopes() *schema.Resource {
 		ReadContext:   resourceKeycloakRealmOptionalClientScopesRead,
 		DeleteContext: resourceKeycloakRealmOptionalClientScopesDelete,
 		UpdateContext: resourceKeycloakRealmOptionalClientScopesReconcile,
+		Importer: &schema.ResourceImporter{
+			// Import id is the realm id (the resource id is the realm id too).
+			StateContext: resourceKeycloakRealmOptionalClientScopesImport,
+		},
 		Schema: map[string]*schema.Schema{
 			"realm_id": {
 				Type:     schema.TypeString,
@@ -97,4 +101,14 @@ func resourceKeycloakRealmOptionalClientScopesDelete(ctx context.Context, data *
 	optionalClientScopes := data.Get("optional_scopes").(*schema.Set)
 
 	return diag.FromErr(keycloakClient.UnmarkClientScopesAsRealmOptional(ctx, realmId, interfaceSliceToStringSlice(optionalClientScopes.List())))
+}
+
+// resourceKeycloakRealmOptionalClientScopesImport adopts the realm-level optional
+// client scopes into state. The import id is the realm id; realm_id is required
+// by the Read, so it is populated from the id before Read runs (which then
+// resolves the current optional scopes and sets the resource id to the realm id).
+func resourceKeycloakRealmOptionalClientScopesImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("realm_id", d.Id())
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/provider/resource_keycloak_realm_optional_client_scopes_test.go
+++ b/provider/resource_keycloak_realm_optional_client_scopes_test.go
@@ -30,6 +30,18 @@ func TestAccKeycloakRealmOptionalClientScopes_basic(t *testing.T) {
 						[]string{"address", "phone", "offline_access", clientScope},
 					),
 				},
+				{
+					ResourceName:      "keycloak_realm_optional_client_scopes.optional_scopes",
+					ImportState:       true,
+					ImportStateVerify: true,
+					ImportStateIdFunc: func(s *terraform.State) (string, error) {
+						rs, ok := s.RootModule().Resources["keycloak_realm_optional_client_scopes.optional_scopes"]
+						if !ok {
+							return "", fmt.Errorf("resource not found: keycloak_realm_optional_client_scopes.optional_scopes")
+						}
+						return rs.Primary.Attributes["realm_id"], nil
+					},
+				},
 			},
 		},
 	)


### PR DESCRIPTION
## Description

`keycloak_realm_default_client_scopes` and `keycloak_realm_optional_client_scopes` reconcile a realm's default/optional client scopes, but neither defines an `Importer`. As a result, an `import {}` block (or `terraform import`) against an existing realm errors with *"resource ... doesn't support import"*, and the only way to bring a realm's pre-existing scopes under management is an opaque create.

This PR adds a `StateContext` importer to each resource. The import id is the **realm id** (which is also the resource id). The importer sets `realm_id` from the id; the existing `Read` then resolves the realm's current scopes into state. This lets operators adopt a realm's existing (e.g. Keycloak factory) scopes and review the exact delta to their declared set in the plan, instead of starting from a create.

## Changes

- `keycloak_realm_default_client_scopes`: add importer + import function.
- `keycloak_realm_optional_client_scopes`: same, for consistency (it had the identical gap).
- Add an `ImportStateVerify` step to each resource's basic acceptance test (import id derived from `realm_id`).
- Replace the "does not support import" note in both doc pages with an `## Import` section + `terraform import` example.
- CHANGELOG entry.

## Usage

```bash
terraform import keycloak_realm_default_client_scopes.default_scopes <realm-id>
terraform import keycloak_realm_optional_client_scopes.optional_scopes <realm-id>
```

## Checklist

- [x] `make vet` passes
- [x] `make fmtcheck` passes
- [x] `ImportStateVerify` acceptance test coverage added for both resources
- [x] Documentation updated