### PR TITLE
feat: support import for realm localization

### DIFF
--- a/docs/resources/realm_localization.md
+++ b/docs/resources/realm_localization.md
@@ -35,4 +35,11 @@ resource "keycloak_realm_localization" "german_texts" {
 
 ## Import
 
-This resource does not currently support importing.
+This resource can be imported using the format `{{realm_id}}/{{locale}}`, where `locale` is the language code the
+localization texts apply to.
+
+Example:
+
+```bash
+$ terraform import keycloak_realm_localization.german_texts my-realm/de
+```

--- a/provider/resource_keycloak_realm_localization.go
+++ b/provider/resource_keycloak_realm_localization.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,7 +16,10 @@ func resourceKeycloakRealmLocalization() *schema.Resource {
 		ReadContext:   resourceKeycloakRealmLocalizationTextsRead,
 		DeleteContext: resourceKeycloakRealmLocalizationTextsDelete,
 		UpdateContext: resourceKeycloakRealmLocalizationTextsUpdate,
-		Description:   "Manage realm-level localization texts.",
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceKeycloakRealmLocalizationTextsImport,
+		},
+		Description: "Manage realm-level localization texts.",
 		Schema: map[string]*schema.Schema{
 			"realm_id": {
 				Type:        schema.TypeString,
@@ -83,6 +87,23 @@ func resourceKeycloakRealmLocalizationTextsDelete(ctx context.Context, d *schema
 
 	d.SetId("")
 	return nil
+}
+
+func resourceKeycloakRealmLocalizationTextsImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid import. Supported import format: {{realmId}}/{{locale}}")
+	}
+
+	d.Set("realm_id", parts[0])
+	d.Set("locale", parts[1])
+
+	diagnostics := resourceKeycloakRealmLocalizationTextsRead(ctx, d, meta)
+	if diagnostics.HasError() {
+		return nil, fmt.Errorf("%s", diagnostics[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func convertTexts(texts map[string]interface{}) map[string]string {

--- a/provider/resource_keycloak_realm_localization_test.go
+++ b/provider/resource_keycloak_realm_localization_test.go
@@ -22,6 +22,11 @@ func TestAccKeycloakRealmLocalizationTexts_basic(t *testing.T) {
 				Config: testKeycloakRealmLocalizationTexts_basic(realmName),
 				Check:  testAccCheckKeycloakRealmLocalizationTextsExist("keycloak_realm_localization.realm_localization", "en", map[string]string{"k": "v"}),
 			},
+			{
+				ResourceName:      "keycloak_realm_localization.realm_localization",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -37,6 +42,11 @@ func TestAccKeycloakRealmLocalizationTexts_empty(t *testing.T) {
 			{
 				Config: testKeycloakRealmLocalizationTexts_empty(realmName),
 				Check:  testAccCheckKeycloakRealmLocalizationTextsExist("keycloak_realm_localization.realm_localization", "en", map[string]string{}),
+			},
+			{
+				ResourceName:      "keycloak_realm_localization.realm_localization",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -55,6 +65,34 @@ func TestAccKeycloakRealmLocalizationTexts_noLocalization(t *testing.T) {
 			{
 				Config: testKeycloakRealmLocalizationTexts_noInternationalization(realmName),
 				Check:  testAccCheckKeycloakRealmLocalizationTextsExist("keycloak_realm_localization.realm_localization", "de", map[string]string{"k": "v"}),
+			},
+			{
+				ResourceName:      "keycloak_realm_localization.realm_localization",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Tests importing a realm localization using the documented "{{realm_id}}/{{locale}}" ID format.
+func TestAccKeycloakRealmLocalizationTexts_import(t *testing.T) {
+	realmName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakRealmLocalizationTextsDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakRealmLocalizationTexts_basic(realmName),
+				Check:  testAccCheckKeycloakRealmLocalizationTextsExist("keycloak_realm_localization.realm_localization", "en", map[string]string{"k": "v"}),
+			},
+			{
+				ResourceName:      "keycloak_realm_localization.realm_localization",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%s/%s", realmName, "en"),
 			},
 		},
 	})


### PR DESCRIPTION
Add Importer to keycloak_realm_localization using the {{realm_id}}/{{locale}} ID format, with acceptance tests and updated docs.

Fixes #1626