### PR TITLE
feat: align the workflow resource with WorkflowRepresentation

### DIFF
--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -86,6 +86,79 @@ resource "keycloak_workflow" "offboard" {
 }
 ```
 
+### Onboard gold members only
+
+This mirrors the [common use cases guide](https://www.keycloak.org/docs/latest/server_admin/index.html#_understanding_common_use_cases).
+The `conditions` expression restricts the workflow to users that have the `membership=gold` attribute, then
+sends a welcome message and grants the `gold-member` role.
+
+```hcl
+resource "keycloak_workflow" "onboard_gold_members" {
+  realm      = keycloak_realm.realm.id
+  name       = "onboarding-gold-members"
+  on         = "user_created"
+  enabled    = true
+  conditions = "has-user-attribute(membership=gold)"
+
+  step {
+    uses = "notify-user"
+    config = {
+      message = "Welcome to the Gold Membership program!"
+    }
+  }
+
+  step {
+    uses = "grant-role"
+    config = {
+      role = "gold-member"
+    }
+  }
+}
+```
+
+### Track inactive users on a schedule
+
+This example mirrors the [scheduling workflows guide](https://www.keycloak.org/docs/latest/server_admin/index.html#_scheduling_workflows).
+Instead of reacting to a single event, the workflow engine periodically scans realm resources (here, every
+`30s`, up to `100` users per run) and progresses each matching user through the steps. `restart_in_progress`
+restarts an in-progress execution when the user authenticates again, so the inactivity countdown resets.
+
+```hcl
+resource "keycloak_workflow" "track_inactive_users" {
+  realm               = keycloak_realm.realm.id
+  name                = "track-inactive-users"
+  on                  = "user_authenticated"
+  enabled             = true
+  restart_in_progress = "true"
+
+  schedule {
+    after      = "30s"
+    batch_size = 100
+  }
+
+  step {
+    uses  = "notify-user"
+    after = "180d"
+    config = {
+      message = "It has been a while since your last login. We miss you!"
+    }
+  }
+
+  step {
+    uses  = "notify-user"
+    after = "60d"
+    config = {
+      message = "Your account will be disabled in $${workflow.daysUntilNextStep} days!"
+    }
+  }
+
+  step {
+    uses  = "disable-user"
+    after = "7d"
+  }
+}
+```
+
 ## Argument Reference
 
 - `realm` - (Required) The realm this workflow exists in. Changing this forces a new resource.
@@ -93,15 +166,32 @@ resource "keycloak_workflow" "offboard" {
 - `on` - (Required) The realm event that triggers the workflow. Supported values: `user_created`, `user_removed`, `user_authenticated`, `user_federated_identity_added`, `user_federated_identity_removed`, `user_group_membership_added`, `user_group_membership_removed`, `user_role_granted`, `user_role_revoked`.
 - `enabled` - (Optional) Whether the workflow is enabled. Defaults to `true`.
 - `conditions` - (Optional) An expression that must evaluate to true for the workflow to run (e.g. `has-role('some-role')`).
-- `cancel_in_progress` - (Optional) Event that cancels an in-progress workflow execution.
-- `restart_in_progress` - (Optional) Event that restarts an in-progress workflow execution.
+- `cancel_in_progress` - (Optional) Whether to cancel an already in-progress execution when the workflow is re-triggered for the same resource. Set to `"true"` to enable.
+- `restart_in_progress` - (Optional) Whether to restart an already in-progress execution (resetting it to the first step) when the workflow is re-triggered for the same resource. Set to `"true"` to enable.
+- `schedule` - (Optional) A [schedule block](#schedule-arguments) that makes the workflow run periodically over matching realm resources instead of (or in addition to) reacting to a single event.
 - `step` - (Required) One or more [step blocks](#step-arguments) defining the actions to execute, in order.
+
+### Schedule arguments
+
+- `after` - (Optional) Interval between successive scheduled runs, as a duration string (e.g. `30s`, `1d`).
+- `batch_size` - (Optional) Maximum number of realm resources processed during each scheduled run.
 
 ### Step arguments
 
 - `uses` - (Required) The step type. Built-in values: `disable-user`, `delete-user`, `notify-user`, `set-user-required-action`, `set-user-attribute`.
-- `after` - (Optional) Delay in milliseconds before executing this step.
+- `after` - (Optional) Delay before executing this step, as a duration string (e.g. `7d`) or milliseconds (e.g. `2592000000`).
+- `priority` - (Optional) Execution priority used to order steps that would otherwise run at the same time.
 - `config` - (Optional) A map of key-value pairs configuring the step (e.g. `emailTemplate` for `notify-user`).
+
+## Attributes Reference
+
+In addition to the arguments above, the following read-only attributes are exported:
+
+- `state` - The runtime state of the workflow as reported by Keycloak. Contains:
+  - `errors` - A list of error messages recorded for the workflow.
+- Each `step` block additionally exports:
+  - `scheduled_at` - Epoch timestamp in milliseconds at which the step is scheduled to execute.
+  - `status` - The execution status of the step.
 
 ## Import
 

--- a/example/workflows.tf
+++ b/example/workflows.tf
@@ -63,8 +63,44 @@ resource "keycloak_workflow" "set_attribute_on_group_join" {
   step {
     uses = "set-user-attribute"
     config = {
-      field1     = "bar"
+      field1 = "bar"
     }
+  }
+}
+
+# Scheduled workflow: periodically scan users and progress inactive ones through reminders,
+# then disable them. Mirrors the "Track inactive users" example from the Keycloak docs.
+resource "keycloak_workflow" "track_inactive_users" {
+  realm               = keycloak_realm.workflows.id
+  name                = "track-inactive-users"
+  on                  = "user_authenticated"
+  enabled             = true
+  restart_in_progress = "true"
+
+  schedule {
+    after      = "30s"
+    batch_size = 100
+  }
+
+  step {
+    uses  = "notify-user"
+    after = "180d"
+    config = {
+      message = "It has been a while since your last login. We miss you!"
+    }
+  }
+
+  step {
+    uses  = "notify-user"
+    after = "60d"
+    config = {
+      message = "Your account will be disabled in $${workflow.daysUntilNextStep} days!"
+    }
+  }
+
+  step {
+    uses  = "disable-user"
+    after = "7d"
   }
 }
 

--- a/keycloak/workflow.go
+++ b/keycloak/workflow.go
@@ -7,22 +7,48 @@ import (
 )
 
 type WorkflowStep struct {
-	Id     string            `json:"id,omitempty"`
-	Uses   string            `json:"uses"`
-	After  string            `json:"after,omitempty"`
-	Config map[string]string `json:"with,omitempty"`
+	Id    string `json:"id,omitempty"`
+	Uses  string `json:"uses"`
+	After string `json:"after,omitempty"`
+	// Priority controls the execution order of steps that would otherwise run at the same time.
+	Priority string            `json:"priority,omitempty"`
+	Config   map[string]string `json:"with,omitempty"`
+	// ScheduledAt and Status are runtime values populated by Keycloak; they are read-only.
+	ScheduledAt int64  `json:"scheduledAt,omitempty"`
+	Status      string `json:"status,omitempty"`
+}
+
+// WorkflowConcurrency holds the concurrency settings of a workflow. Keycloak expects these
+// to be nested inside a "concurrency" object with kebab-case keys, not as flat fields on the
+// workflow itself.
+type WorkflowConcurrency struct {
+	CancelInProgress  string `json:"cancel-in-progress,omitempty"`
+	RestartInProgress string `json:"restart-in-progress,omitempty"`
+}
+
+// WorkflowSchedule holds the scheduling settings of a workflow, nested under a "schedule" object.
+type WorkflowSchedule struct {
+	After     string `json:"after,omitempty"`
+	BatchSize int    `json:"batch-size,omitempty"`
+}
+
+// WorkflowState is the runtime state of a workflow as reported by Keycloak. It is read-only.
+type WorkflowState struct {
+	Errors []string `json:"errors,omitempty"`
 }
 
 type Workflow struct {
-	Id                string         `json:"id,omitempty"`
-	Realm             string         `json:"-"`
-	Name              string         `json:"name"`
-	On                string         `json:"on"`
-	Enabled           bool           `json:"enabled"`
-	Conditions        string         `json:"if,omitempty"`
-	Steps             []WorkflowStep `json:"steps"`
-	CancelInProgress  string         `json:"cancelInProgress,omitempty"`
-	RestartInProgress string         `json:"restartInProgress,omitempty"`
+	Id          string               `json:"id,omitempty"`
+	Realm       string               `json:"-"`
+	Name        string               `json:"name"`
+	On          string               `json:"on"`
+	Enabled     bool                 `json:"enabled"`
+	Conditions  string               `json:"if,omitempty"`
+	Steps       []WorkflowStep       `json:"steps"`
+	Concurrency *WorkflowConcurrency `json:"concurrency,omitempty"`
+	Schedule    *WorkflowSchedule    `json:"schedule,omitempty"`
+	// State is runtime state populated by Keycloak; it is read-only and never sent on writes.
+	State *WorkflowState `json:"state,omitempty"`
 }
 
 func (keycloakClient *KeycloakClient) NewWorkflow(ctx context.Context, workflow *Workflow) error {

--- a/keycloak/workflow_test.go
+++ b/keycloak/workflow_test.go
@@ -1,0 +1,179 @@
+package keycloak
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Regression test for https://github.com/keycloak/terraform-provider-keycloak/issues/1622:
+// concurrency settings must be marshaled into a nested "concurrency" object with kebab-case
+// keys, not as flat "cancelInProgress"/"restartInProgress" fields that Keycloak ignores.
+func TestWorkflowConcurrencyMarshaling(t *testing.T) {
+	workflow := &Workflow{
+		Name:    "test-workflow",
+		On:      "user_authenticated",
+		Enabled: true,
+		Steps:   []WorkflowStep{{Uses: "disable-user", After: "300000"}},
+		Concurrency: &WorkflowConcurrency{
+			RestartInProgress: "true",
+		},
+	}
+
+	data, err := json.Marshal(workflow)
+	if err != nil {
+		t.Fatalf("failed to marshal workflow: %s", err)
+	}
+
+	body := string(data)
+
+	if !strings.Contains(body, `"concurrency":{"restart-in-progress":"true"}`) {
+		t.Errorf("expected nested concurrency object with kebab-case keys, got: %s", body)
+	}
+
+	for _, flat := range []string{`"restartInProgress"`, `"cancelInProgress"`, `"restart_in_progress"`} {
+		if strings.Contains(body, flat) {
+			t.Errorf("expected concurrency settings to be nested, but found flat field %s in: %s", flat, body)
+		}
+	}
+}
+
+// Workflows without concurrency settings must omit the "concurrency" key entirely.
+func TestWorkflowConcurrencyOmittedWhenEmpty(t *testing.T) {
+	workflow := &Workflow{
+		Name:    "test-workflow",
+		On:      "user_authenticated",
+		Enabled: true,
+		Steps:   []WorkflowStep{{Uses: "disable-user", After: "300000"}},
+	}
+
+	data, err := json.Marshal(workflow)
+	if err != nil {
+		t.Fatalf("failed to marshal workflow: %s", err)
+	}
+
+	if body := string(data); strings.Contains(body, "concurrency") {
+		t.Errorf("expected no concurrency key when concurrency is unset, got: %s", body)
+	}
+}
+
+// The nested concurrency object returned by Keycloak must unmarshal back into the struct,
+// so reads and imports populate the concurrency settings.
+func TestWorkflowConcurrencyUnmarshaling(t *testing.T) {
+	body := `{
+		"name": "test-workflow",
+		"on": "user_authenticated",
+		"enabled": true,
+		"concurrency": {"cancel-in-progress": "true", "restart-in-progress": "false"},
+		"steps": [{"uses": "disable-user", "after": "300000"}]
+	}`
+
+	var workflow Workflow
+	if err := json.Unmarshal([]byte(body), &workflow); err != nil {
+		t.Fatalf("failed to unmarshal workflow: %s", err)
+	}
+
+	if workflow.Concurrency == nil {
+		t.Fatal("expected concurrency to be populated, got nil")
+	}
+	if workflow.Concurrency.CancelInProgress != "true" {
+		t.Errorf("expected cancel-in-progress %q, got %q", "true", workflow.Concurrency.CancelInProgress)
+	}
+	if workflow.Concurrency.RestartInProgress != "false" {
+		t.Errorf("expected restart-in-progress %q, got %q", "false", workflow.Concurrency.RestartInProgress)
+	}
+}
+
+// The schedule settings must be marshaled into a nested "schedule" object with kebab-case keys,
+// matching Keycloak's WorkflowScheduleRepresentation.
+func TestWorkflowScheduleMarshaling(t *testing.T) {
+	workflow := &Workflow{
+		Name:    "test-workflow",
+		On:      "user_authenticated",
+		Enabled: true,
+		Steps:   []WorkflowStep{{Uses: "disable-user", After: "300000"}},
+		Schedule: &WorkflowSchedule{
+			After:     "86400000",
+			BatchSize: 100,
+		},
+	}
+
+	data, err := json.Marshal(workflow)
+	if err != nil {
+		t.Fatalf("failed to marshal workflow: %s", err)
+	}
+
+	if body := string(data); !strings.Contains(body, `"schedule":{"after":"86400000","batch-size":100}`) {
+		t.Errorf("expected nested schedule object with kebab-case keys, got: %s", body)
+	}
+}
+
+// Workflows without a schedule must omit the "schedule" key entirely, and read-only "state"
+// must never be sent on writes.
+func TestWorkflowScheduleAndStateOmittedWhenEmpty(t *testing.T) {
+	workflow := &Workflow{
+		Name:    "test-workflow",
+		On:      "user_authenticated",
+		Enabled: true,
+		Steps:   []WorkflowStep{{Uses: "disable-user", After: "300000"}},
+	}
+
+	data, err := json.Marshal(workflow)
+	if err != nil {
+		t.Fatalf("failed to marshal workflow: %s", err)
+	}
+
+	body := string(data)
+	if strings.Contains(body, "schedule") {
+		t.Errorf("expected no schedule key when schedule is unset, got: %s", body)
+	}
+	if strings.Contains(body, "state") {
+		t.Errorf("expected no state key when state is unset, got: %s", body)
+	}
+}
+
+// The nested schedule and runtime state/step fields returned by Keycloak must unmarshal back
+// into the struct so reads and imports populate them.
+func TestWorkflowScheduleAndStateUnmarshaling(t *testing.T) {
+	body := `{
+		"name": "test-workflow",
+		"on": "user_authenticated",
+		"enabled": true,
+		"schedule": {"after": "86400000", "batch-size": 50},
+		"state": {"errors": ["boom"]},
+		"steps": [{"uses": "disable-user", "after": "300000", "priority": "10", "scheduledAt": 1700000000000, "status": "SCHEDULED"}]
+	}`
+
+	var workflow Workflow
+	if err := json.Unmarshal([]byte(body), &workflow); err != nil {
+		t.Fatalf("failed to unmarshal workflow: %s", err)
+	}
+
+	if workflow.Schedule == nil {
+		t.Fatal("expected schedule to be populated, got nil")
+	}
+	if workflow.Schedule.After != "86400000" {
+		t.Errorf("expected schedule after %q, got %q", "86400000", workflow.Schedule.After)
+	}
+	if workflow.Schedule.BatchSize != 50 {
+		t.Errorf("expected schedule batch-size %d, got %d", 50, workflow.Schedule.BatchSize)
+	}
+
+	if workflow.State == nil || len(workflow.State.Errors) != 1 || workflow.State.Errors[0] != "boom" {
+		t.Errorf("expected state errors [boom], got %+v", workflow.State)
+	}
+
+	if len(workflow.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(workflow.Steps))
+	}
+	step := workflow.Steps[0]
+	if step.Priority != "10" {
+		t.Errorf("expected step priority %q, got %q", "10", step.Priority)
+	}
+	if step.ScheduledAt != 1700000000000 {
+		t.Errorf("expected step scheduledAt %d, got %d", int64(1700000000000), step.ScheduledAt)
+	}
+	if step.Status != "SCHEDULED" {
+		t.Errorf("expected step status %q, got %q", "SCHEDULED", step.Status)
+	}
+}

--- a/provider/data_source_keycloak_workflow.go
+++ b/provider/data_source_keycloak_workflow.go
@@ -42,6 +42,35 @@ func dataSourceKeycloakWorkflow() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"schedule": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"after": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"batch_size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"state": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"errors": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
 			"step": {
 				Type:       schema.TypeList,
 				Computed:   true,
@@ -56,10 +85,22 @@ func dataSourceKeycloakWorkflow() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"priority": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"config": {
 							Type:     schema.TypeMap,
 							Computed: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"scheduled_at": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 					},
 				},

--- a/provider/resource_keycloak_workflow.go
+++ b/provider/resource_keycloak_workflow.go
@@ -57,6 +57,41 @@ func resourceKeycloakWorkflow() *schema.Resource {
 				Optional:    true,
 				Description: "Event that restarts an in-progress workflow execution.",
 			},
+			"schedule": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Scheduling configuration for the workflow.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"after": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Interval between successive scheduled runs, as a duration string (e.g. 30s, 1d) or milliseconds.",
+						},
+						"batch_size": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Maximum number of resources processed per scheduled batch.",
+						},
+					},
+				},
+			},
+			"state": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Runtime state of the workflow, as reported by Keycloak.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"errors": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Description: "Errors recorded for the workflow.",
+						},
+					},
+				},
+			},
 			"step": {
 				Type:        schema.TypeList,
 				Required:    true,
@@ -72,13 +107,28 @@ func resourceKeycloakWorkflow() *schema.Resource {
 						"after": {
 							Type:        schema.TypeString,
 							Optional:    true,
-							Description: "Delay in milliseconds before executing this step.",
+							Description: "Delay before executing this step, as a duration string (e.g. 7d) or milliseconds (e.g. 2592000000).",
+						},
+						"priority": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Execution priority of the step, used to order steps that would otherwise run at the same time.",
 						},
 						"config": {
 							Type:        schema.TypeMap,
 							Optional:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: "Key-value configuration for the step.",
+						},
+						"scheduled_at": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Epoch timestamp in milliseconds at which the step is scheduled to execute.",
+						},
+						"status": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Execution status of the step, as reported by Keycloak.",
 						},
 					},
 				},
@@ -89,14 +139,32 @@ func resourceKeycloakWorkflow() *schema.Resource {
 
 func getWorkflowFromData(data *schema.ResourceData) *keycloak.Workflow {
 	workflow := &keycloak.Workflow{
-		Id:                data.Id(),
-		Realm:             data.Get("realm").(string),
-		Name:              data.Get("name").(string),
-		On:                data.Get("on").(string),
-		Enabled:           data.Get("enabled").(bool),
-		Conditions:        data.Get("conditions").(string),
-		CancelInProgress:  data.Get("cancel_in_progress").(string),
-		RestartInProgress: data.Get("restart_in_progress").(string),
+		Id:         data.Id(),
+		Realm:      data.Get("realm").(string),
+		Name:       data.Get("name").(string),
+		On:         data.Get("on").(string),
+		Enabled:    data.Get("enabled").(bool),
+		Conditions: data.Get("conditions").(string),
+	}
+
+	cancelInProgress := data.Get("cancel_in_progress").(string)
+	restartInProgress := data.Get("restart_in_progress").(string)
+	if cancelInProgress != "" || restartInProgress != "" {
+		workflow.Concurrency = &keycloak.WorkflowConcurrency{
+			CancelInProgress:  cancelInProgress,
+			RestartInProgress: restartInProgress,
+		}
+	}
+
+	if v, ok := data.GetOk("schedule"); ok {
+		scheduleList := v.([]interface{})
+		if len(scheduleList) == 1 && scheduleList[0] != nil {
+			scheduleMap := scheduleList[0].(map[string]interface{})
+			workflow.Schedule = &keycloak.WorkflowSchedule{
+				After:     scheduleMap["after"].(string),
+				BatchSize: scheduleMap["batch_size"].(int),
+			}
+		}
 	}
 
 	steps := make([]keycloak.WorkflowStep, 0)
@@ -104,8 +172,9 @@ func getWorkflowFromData(data *schema.ResourceData) *keycloak.Workflow {
 		for _, raw := range v.([]interface{}) {
 			stepMap := raw.(map[string]interface{})
 			step := keycloak.WorkflowStep{
-				Uses:  stepMap["uses"].(string),
-				After: stepMap["after"].(string),
+				Uses:     stepMap["uses"].(string),
+				After:    stepMap["after"].(string),
+				Priority: stepMap["priority"].(string),
 			}
 			if cfgRaw, ok := stepMap["config"]; ok {
 				config := make(map[string]string)
@@ -129,14 +198,47 @@ func setWorkflowData(data *schema.ResourceData, workflow *keycloak.Workflow) {
 	data.Set("on", workflow.On)
 	data.Set("enabled", workflow.Enabled)
 	data.Set("conditions", workflow.Conditions)
-	data.Set("cancel_in_progress", workflow.CancelInProgress)
-	data.Set("restart_in_progress", workflow.RestartInProgress)
+	if workflow.Concurrency != nil {
+		data.Set("cancel_in_progress", workflow.Concurrency.CancelInProgress)
+		data.Set("restart_in_progress", workflow.Concurrency.RestartInProgress)
+	} else {
+		data.Set("cancel_in_progress", "")
+		data.Set("restart_in_progress", "")
+	}
+
+	if workflow.Schedule != nil {
+		data.Set("schedule", []interface{}{
+			map[string]interface{}{
+				"after":      workflow.Schedule.After,
+				"batch_size": workflow.Schedule.BatchSize,
+			},
+		})
+	} else {
+		data.Set("schedule", []interface{}{})
+	}
+
+	if workflow.State != nil {
+		errors := make([]interface{}, 0, len(workflow.State.Errors))
+		for _, e := range workflow.State.Errors {
+			errors = append(errors, e)
+		}
+		data.Set("state", []interface{}{
+			map[string]interface{}{
+				"errors": errors,
+			},
+		})
+	} else {
+		data.Set("state", []interface{}{})
+	}
 
 	steps := make([]map[string]interface{}, 0, len(workflow.Steps))
 	for _, step := range workflow.Steps {
 		stepMap := map[string]interface{}{
-			"uses":  step.Uses,
-			"after": step.After,
+			"uses":         step.Uses,
+			"after":        step.After,
+			"priority":     step.Priority,
+			"scheduled_at": int(step.ScheduledAt),
+			"status":       step.Status,
 		}
 		if len(step.Config) > 0 {
 			config := make(map[string]interface{})

--- a/provider/resource_keycloak_workflow_test.go
+++ b/provider/resource_keycloak_workflow_test.go
@@ -52,6 +52,76 @@ func TestAccKeycloakWorkflow_update(t *testing.T) {
 	})
 }
 
+// Regression test for https://github.com/keycloak/terraform-provider-keycloak/issues/1622:
+// restart_in_progress / cancel_in_progress must be persisted by Keycloak (sent as a nested
+// "concurrency" object), not silently dropped.
+func TestAccKeycloakWorkflow_concurrency(t *testing.T) {
+	skipIfVersionIsLessThan(testCtx, t, keycloakClient, keycloak.Version_26_5)
+	workflowName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakWorkflowDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakWorkflow_withConcurrency(workflowName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakWorkflowExists("keycloak_workflow.workflow"),
+					resource.TestCheckResourceAttr("keycloak_workflow.workflow", "restart_in_progress", "true"),
+					testAccCheckKeycloakWorkflowHasConcurrency("keycloak_workflow.workflow", "", "true"),
+				),
+			},
+			{
+				ResourceName:      "keycloak_workflow.workflow",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["keycloak_workflow.workflow"]
+					if !ok {
+						return "", fmt.Errorf("resource not found")
+					}
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["realm"], rs.Primary.ID), nil
+				},
+			},
+		},
+	})
+}
+
+func TestAccKeycloakWorkflow_schedule(t *testing.T) {
+	skipIfVersionIsLessThan(testCtx, t, keycloakClient, keycloak.Version_26_5)
+	workflowName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakWorkflowDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakWorkflow_withSchedule(workflowName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakWorkflowExists("keycloak_workflow.workflow"),
+					resource.TestCheckResourceAttr("keycloak_workflow.workflow", "schedule.0.after", "86400000"),
+					resource.TestCheckResourceAttr("keycloak_workflow.workflow", "schedule.0.batch_size", "100"),
+					testAccCheckKeycloakWorkflowHasSchedule("keycloak_workflow.workflow", "86400000", 100),
+				),
+			},
+			{
+				ResourceName:      "keycloak_workflow.workflow",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["keycloak_workflow.workflow"]
+					if !ok {
+						return "", fmt.Errorf("resource not found")
+					}
+					return fmt.Sprintf("%s/%s", rs.Primary.Attributes["realm"], rs.Primary.ID), nil
+				},
+			},
+		},
+	})
+}
+
 func TestAccKeycloakWorkflow_createAfterManualDestroy(t *testing.T) {
 	skipIfVersionIsLessThan(testCtx, t, keycloakClient, keycloak.Version_26_5)
 	var workflow = &keycloak.Workflow{}
@@ -116,6 +186,52 @@ func testAccCheckKeycloakWorkflowExists(resourceName string) resource.TestCheckF
 	return func(s *terraform.State) error {
 		_, err := getWorkflowFromState(s, resourceName)
 		return err
+	}
+}
+
+// testAccCheckKeycloakWorkflowHasConcurrency verifies that Keycloak actually persisted the
+// concurrency settings, by reading the workflow back from the API rather than from state.
+func testAccCheckKeycloakWorkflowHasConcurrency(resourceName, expectedCancel, expectedRestart string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		workflow, err := getWorkflowFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if workflow.Concurrency == nil {
+			return fmt.Errorf("expected concurrency to be persisted, but it was nil")
+		}
+		if workflow.Concurrency.CancelInProgress != expectedCancel {
+			return fmt.Errorf("expected cancel-in-progress %q, got %q", expectedCancel, workflow.Concurrency.CancelInProgress)
+		}
+		if workflow.Concurrency.RestartInProgress != expectedRestart {
+			return fmt.Errorf("expected restart-in-progress %q, got %q", expectedRestart, workflow.Concurrency.RestartInProgress)
+		}
+
+		return nil
+	}
+}
+
+// testAccCheckKeycloakWorkflowHasSchedule verifies that Keycloak persisted the schedule settings
+// by reading the workflow back from the API.
+func testAccCheckKeycloakWorkflowHasSchedule(resourceName, expectedAfter string, expectedBatchSize int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		workflow, err := getWorkflowFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if workflow.Schedule == nil {
+			return fmt.Errorf("expected schedule to be persisted, but it was nil")
+		}
+		if workflow.Schedule.After != expectedAfter {
+			return fmt.Errorf("expected schedule after %q, got %q", expectedAfter, workflow.Schedule.After)
+		}
+		if workflow.Schedule.BatchSize != expectedBatchSize {
+			return fmt.Errorf("expected schedule batch-size %d, got %d", expectedBatchSize, workflow.Schedule.BatchSize)
+		}
+
+		return nil
 	}
 }
 
@@ -185,6 +301,52 @@ resource "keycloak_workflow" "workflow" {
 
 	step {
 		uses = "disable-user"
+		after = "86400000"
+	}
+}
+`, testAccRealm.Realm, name)
+}
+
+func testKeycloakWorkflow_withConcurrency(name string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_workflow" "workflow" {
+	realm               = data.keycloak_realm.realm.id
+	name                = "%s"
+	on                  = "user_authenticated"
+	enabled             = true
+	restart_in_progress = "true"
+
+	step {
+		uses  = "disable-user"
+		after = "86400000"
+	}
+}
+`, testAccRealm.Realm, name)
+}
+
+func testKeycloakWorkflow_withSchedule(name string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_workflow" "workflow" {
+	realm   = data.keycloak_realm.realm.id
+	name    = "%s"
+	on      = "user_authenticated"
+	enabled = true
+
+	schedule {
+		after      = "86400000"
+		batch_size = 100
+	}
+
+	step {
+		uses  = "disable-user"
 		after = "86400000"
 	}
 }


### PR DESCRIPTION
- Fix concurrency: send cancel_in_progress/restart_in_progress nested in a "concurrency" object with kebab-case keys instead of flat fields Keycloak silently ignores (#1622)
- Add user-configurable schedule block (after, batch_size)
- Add user-configurable step priority
- Expose read-only runtime fields: state.errors and step scheduled_at/status as Computed attributes

Update the data source schema, docs (with examples adapted from the Keycloak workflow guide), and example config. Add JSON marshaling unit tests and acceptance tests for concurrency and schedule.

Fixes #1628, #1622