### PR TITLE
Add `add_to_token_introspection` to keycloak_openid_group_membership_protocol_mapper and keycloak_openid_audience_protocol_mapper

### DIFF
--- a/docs/resources/openid_audience_protocol_mapper.md
+++ b/docs/resources/openid_audience_protocol_mapper.md
@@ -71,6 +71,7 @@ resource "keycloak_openid_audience_protocol_mapper" "audience_mapper" {
 - `included_custom_audience` - (Optional) A custom audience to include within the token's `aud` claim. Conflicts with `included_client_audience`. One of `included_client_audience` or `included_custom_audience` must be specified.
 - `add_to_id_token` - (Optional) Indicates if the audience should be included in the `aud` claim for the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the audience should be included in the `aud` claim for the id token. Defaults to `true`.
+- `add_to_token_introspection` - (Optional) Indicates if the attribute should be added as a claim on the token introspection response. Defaults to `true`.
 
 ## Import
 

--- a/docs/resources/openid_group_membership_protocol_mapper.md
+++ b/docs/resources/openid_group_membership_protocol_mapper.md
@@ -74,6 +74,7 @@ resource "keycloak_openid_group_membership_protocol_mapper" "group_membership_ma
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.
 - `add_to_userinfo` - (Optional) Indicates if the property should be added as a claim to the UserInfo response body. Defaults to `true`.
+- `add_to_token_introspection` - (Optional) Indicates if the attribute should be added as a claim to the token introspection response. Defaults to `false`.
 
 ## Import
 

--- a/keycloak/openid_audience_protocol_mapper.go
+++ b/keycloak/openid_audience_protocol_mapper.go
@@ -13,8 +13,9 @@ type OpenIdAudienceProtocolMapper struct {
 	ClientId      string
 	ClientScopeId string
 
-	AddToIdToken     bool
-	AddToAccessToken bool
+	AddToIdToken            bool
+	AddToAccessToken        bool
+	AddToTokenIntrospection bool
 
 	IncludedClientAudience string
 	IncludedCustomAudience string
@@ -27,10 +28,11 @@ func (mapper *OpenIdAudienceProtocolMapper) convertToGenericProtocolMapper() *pr
 		Protocol:       "openid-connect",
 		ProtocolMapper: "oidc-audience-mapper",
 		Config: map[string]string{
-			addToIdTokenField:           strconv.FormatBool(mapper.AddToIdToken),
-			addToAccessTokenField:       strconv.FormatBool(mapper.AddToAccessToken),
-			includedClientAudienceField: mapper.IncludedClientAudience,
-			includedCustomAudienceField: mapper.IncludedCustomAudience,
+			addToIdTokenField:            strconv.FormatBool(mapper.AddToIdToken),
+			addToAccessTokenField:        strconv.FormatBool(mapper.AddToAccessToken),
+			addToTokenIntrospectionField: strconv.FormatBool(mapper.AddToTokenIntrospection),
+			includedClientAudienceField:  mapper.IncludedClientAudience,
+			includedCustomAudienceField:  mapper.IncludedCustomAudience,
 		},
 	}
 }
@@ -46,6 +48,11 @@ func (protocolMapper *protocolMapper) convertToOpenIdAudienceProtocolMapper(real
 		return nil, err
 	}
 
+	addToTokenIntrospection, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToTokenIntrospectionField])
+	if err != nil {
+		return nil, err
+	}
+
 	return &OpenIdAudienceProtocolMapper{
 		Id:            protocolMapper.Id,
 		Name:          protocolMapper.Name,
@@ -53,8 +60,9 @@ func (protocolMapper *protocolMapper) convertToOpenIdAudienceProtocolMapper(real
 		ClientId:      clientId,
 		ClientScopeId: clientScopeId,
 
-		AddToIdToken:     addToIdToken,
-		AddToAccessToken: addToAccessToken,
+		AddToIdToken:            addToIdToken,
+		AddToAccessToken:        addToAccessToken,
+		AddToTokenIntrospection: addToTokenIntrospection,
 
 		IncludedClientAudience: protocolMapper.Config[includedClientAudienceField],
 		IncludedCustomAudience: protocolMapper.Config[includedCustomAudienceField],

--- a/keycloak/openid_group_membership_protocol_mapper.go
+++ b/keycloak/openid_group_membership_protocol_mapper.go
@@ -13,9 +13,10 @@ type OpenIdGroupMembershipProtocolMapper struct {
 	ClientId      string
 	ClientScopeId string
 
-	AddToIdToken     bool
-	AddToAccessToken bool
-	AddToUserinfo    bool
+	AddToIdToken            bool
+	AddToAccessToken        bool
+	AddToUserinfo           bool
+	AddToTokenIntrospection bool
 
 	ClaimName string
 	FullPath  bool
@@ -28,11 +29,12 @@ func (mapper *OpenIdGroupMembershipProtocolMapper) convertToGenericProtocolMappe
 		Protocol:       "openid-connect",
 		ProtocolMapper: "oidc-group-membership-mapper",
 		Config: map[string]string{
-			fullPathField:         strconv.FormatBool(mapper.FullPath),
-			addToIdTokenField:     strconv.FormatBool(mapper.AddToIdToken),
-			addToAccessTokenField: strconv.FormatBool(mapper.AddToAccessToken),
-			addToUserInfoField:    strconv.FormatBool(mapper.AddToUserinfo),
-			claimNameField:        mapper.ClaimName,
+			fullPathField:                strconv.FormatBool(mapper.FullPath),
+			addToIdTokenField:            strconv.FormatBool(mapper.AddToIdToken),
+			addToAccessTokenField:        strconv.FormatBool(mapper.AddToAccessToken),
+			addToUserInfoField:           strconv.FormatBool(mapper.AddToUserinfo),
+			addToTokenIntrospectionField: strconv.FormatBool(mapper.AddToTokenIntrospection),
+			claimNameField:               mapper.ClaimName,
 		},
 	}
 }
@@ -58,6 +60,11 @@ func (protocolMapper *protocolMapper) convertToOpenIdGroupMembershipProtocolMapp
 		return nil, err
 	}
 
+	addToTokenIntrospectionClaim, err := parseBoolAndTreatEmptyStringAsFalse(protocolMapper.Config[addToTokenIntrospectionField])
+	if err != nil {
+		return nil, err
+	}
+
 	return &OpenIdGroupMembershipProtocolMapper{
 		Id:            protocolMapper.Id,
 		Name:          protocolMapper.Name,
@@ -65,11 +72,12 @@ func (protocolMapper *protocolMapper) convertToOpenIdGroupMembershipProtocolMapp
 		ClientId:      clientId,
 		ClientScopeId: clientScopeId,
 
-		ClaimName:        protocolMapper.Config[claimNameField],
-		FullPath:         fullPath,
-		AddToIdToken:     idTokenClaim,
-		AddToAccessToken: accessTokenClaim,
-		AddToUserinfo:    userinfoTokenClaim,
+		ClaimName:               protocolMapper.Config[claimNameField],
+		FullPath:                fullPath,
+		AddToIdToken:            idTokenClaim,
+		AddToAccessToken:        accessTokenClaim,
+		AddToUserinfo:           userinfoTokenClaim,
+		AddToTokenIntrospection: addToTokenIntrospectionClaim,
 	}, nil
 }
 

--- a/provider/resource_keycloak_openid_audience_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_audience_protocol_mapper.go
@@ -71,6 +71,12 @@ func resourceKeycloakOpenIdAudienceProtocolMapper() *schema.Resource {
 				Default:     true,
 				Description: "Indicates if this claim should be added to the access token.",
 			},
+			"add_to_token_introspection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Indicates if the attribute should be a claim in the token introspection response.",
+			},
 		},
 	}
 }
@@ -83,8 +89,9 @@ func mapFromDataToOpenIdAudienceProtocolMapper(data *schema.ResourceData) *keycl
 		ClientId:      data.Get("client_id").(string),
 		ClientScopeId: data.Get("client_scope_id").(string),
 
-		AddToIdToken:     data.Get("add_to_id_token").(bool),
-		AddToAccessToken: data.Get("add_to_access_token").(bool),
+		AddToIdToken:            data.Get("add_to_id_token").(bool),
+		AddToAccessToken:        data.Get("add_to_access_token").(bool),
+		AddToTokenIntrospection: data.Get("add_to_token_introspection").(bool),
 
 		IncludedClientAudience: data.Get("included_client_audience").(string),
 		IncludedCustomAudience: data.Get("included_custom_audience").(string),
@@ -110,6 +117,7 @@ func mapFromOpenIdAudienceMapperToData(mapper *keycloak.OpenIdAudienceProtocolMa
 
 	data.Set("add_to_id_token", mapper.AddToIdToken)
 	data.Set("add_to_access_token", mapper.AddToAccessToken)
+	data.Set("add_to_token_introspection", mapper.AddToTokenIntrospection)
 }
 
 func resourceKeycloakOpenIdAudienceProtocolMapperCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/provider/resource_keycloak_openid_audience_protocol_mapper_test.go
+++ b/provider/resource_keycloak_openid_audience_protocol_mapper_test.go
@@ -221,6 +221,36 @@ func TestAccKeycloakOpenIdAudienceProtocolMapper_updateRealmIdForceNew(t *testin
 	})
 }
 
+func TestAccKeycloakOpenIdAudienceProtocolMapper_addToTokenIntrospection(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+	mapperName := acctest.RandomWithPrefix("tf-acc")
+
+	resourceName := "keycloak_openid_audience_protocol_mapper.audience_mapper"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccKeycloakOpenIdAudienceProtocolMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenIdAudienceProtocolMapper_addToTokenIntrospection(clientId, mapperName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakOpenIdAudienceProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_to_token_introspection", "false"),
+				),
+			},
+			{
+				Config: testKeycloakOpenIdAudienceProtocolMapper_addToTokenIntrospection(clientId, mapperName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakOpenIdAudienceProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_to_token_introspection", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakOpenIdAudienceProtocolMapper_validateClientAudienceExists(t *testing.T) {
 	t.Parallel()
 	clientId := acctest.RandomWithPrefix("tf-acc")
@@ -450,6 +480,29 @@ resource "keycloak_openid_audience_protocol_mapper" "audience_mapper" {
 	included_client_audience = "${keycloak_openid_client.openid_client.client_id}"
 	included_custom_audience = "foo"
 }`, testAccRealm.Realm, clientId, mapperName)
+}
+
+func testKeycloakOpenIdAudienceProtocolMapper_addToTokenIntrospection(clientId, mapperName string, addToTokenIntrospection bool) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "openid_client" {
+	realm_id  = data.keycloak_realm.realm.id
+	client_id = "%s"
+
+	access_type = "BEARER-ONLY"
+}
+
+resource "keycloak_openid_audience_protocol_mapper" "audience_mapper" {
+	name                       = "%s"
+	realm_id                   = data.keycloak_realm.realm.id
+	client_id                  = "${keycloak_openid_client.openid_client.id}"
+
+	included_custom_audience   = "foo"
+	add_to_token_introspection = %t
+}`, testAccRealm.Realm, clientId, mapperName, addToTokenIntrospection)
 }
 
 func testKeycloakOpenIdAudienceProtocolMapper_validateClientAudienceExists(clientId, mapperName string) string {

--- a/provider/resource_keycloak_openid_group_membership_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_group_membership_protocol_mapper.go
@@ -72,6 +72,11 @@ func resourceKeycloakOpenIdGroupMembershipProtocolMapper() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"add_to_token_introspection": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -84,11 +89,12 @@ func mapFromDataToOpenIdGroupMembershipProtocolMapper(data *schema.ResourceData)
 		ClientId:      data.Get("client_id").(string),
 		ClientScopeId: data.Get("client_scope_id").(string),
 
-		ClaimName:        data.Get("claim_name").(string),
-		FullPath:         data.Get("full_path").(bool),
-		AddToIdToken:     data.Get("add_to_id_token").(bool),
-		AddToAccessToken: data.Get("add_to_access_token").(bool),
-		AddToUserinfo:    data.Get("add_to_userinfo").(bool),
+		ClaimName:               data.Get("claim_name").(string),
+		FullPath:                data.Get("full_path").(bool),
+		AddToIdToken:            data.Get("add_to_id_token").(bool),
+		AddToAccessToken:        data.Get("add_to_access_token").(bool),
+		AddToUserinfo:           data.Get("add_to_userinfo").(bool),
+		AddToTokenIntrospection: data.Get("add_to_token_introspection").(bool),
 	}
 }
 
@@ -108,6 +114,7 @@ func mapFromOpenIdGroupMembershipMapperToData(mapper *keycloak.OpenIdGroupMember
 	data.Set("add_to_id_token", mapper.AddToIdToken)
 	data.Set("add_to_access_token", mapper.AddToAccessToken)
 	data.Set("add_to_userinfo", mapper.AddToUserinfo)
+	data.Set("add_to_token_introspection", mapper.AddToTokenIntrospection)
 }
 
 func resourceKeycloakOpenIdGroupMembershipProtocolMapperCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/provider/resource_keycloak_openid_group_membership_protocol_mapper_test.go
+++ b/provider/resource_keycloak_openid_group_membership_protocol_mapper_test.go
@@ -92,23 +92,25 @@ func TestAccKeycloakOpenIdGroupMembershipProtocolMapper_update(t *testing.T) {
 	resourceName := "keycloak_openid_group_membership_protocol_mapper.group_membership_mapper"
 
 	mapperOne := &keycloak.OpenIdGroupMembershipProtocolMapper{
-		Name:             acctest.RandString(10),
-		ClientId:         "terraform-client-" + acctest.RandString(10),
-		ClaimName:        acctest.RandString(10),
-		FullPath:         randomBool(),
-		AddToIdToken:     randomBool(),
-		AddToAccessToken: randomBool(),
-		AddToUserinfo:    randomBool(),
+		Name:                    acctest.RandString(10),
+		ClientId:                "terraform-client-" + acctest.RandString(10),
+		ClaimName:               acctest.RandString(10),
+		FullPath:                randomBool(),
+		AddToIdToken:            randomBool(),
+		AddToAccessToken:        randomBool(),
+		AddToUserinfo:           randomBool(),
+		AddToTokenIntrospection: randomBool(),
 	}
 
 	mapperTwo := &keycloak.OpenIdGroupMembershipProtocolMapper{
-		Name:             mapperOne.Name,
-		ClientId:         mapperOne.ClientId,
-		ClaimName:        acctest.RandString(10),
-		FullPath:         randomBool(),
-		AddToIdToken:     randomBool(),
-		AddToAccessToken: randomBool(),
-		AddToUserinfo:    randomBool(),
+		Name:                    mapperOne.Name,
+		ClientId:                mapperOne.ClientId,
+		ClaimName:               acctest.RandString(10),
+		FullPath:                randomBool(),
+		AddToIdToken:            randomBool(),
+		AddToAccessToken:        randomBool(),
+		AddToUserinfo:           randomBool(),
+		AddToTokenIntrospection: randomBool(),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -380,16 +382,69 @@ resource "keycloak_openid_client" "openid_client" {
 }
 
 resource "keycloak_openid_group_membership_protocol_mapper" "group_membership_mapper" {
-	name                = "%s"
-	realm_id            = data.keycloak_realm.realm.id
-	client_id           = "${keycloak_openid_client.openid_client.id}"
+	name                       = "%s"
+	realm_id                   = data.keycloak_realm.realm.id
+	client_id                  = "${keycloak_openid_client.openid_client.id}"
 
-	claim_name          = "%s"
-	full_path           = %t
-	add_to_id_token     = %t
-	add_to_access_token = %t
-	add_to_userinfo     = %t
-}`, testAccRealm.Realm, mapper.ClientId, mapper.Name, mapper.ClaimName, mapper.FullPath, mapper.AddToIdToken, mapper.AddToAccessToken, mapper.AddToUserinfo)
+	claim_name                 = "%s"
+	full_path                  = %t
+	add_to_id_token            = %t
+	add_to_access_token        = %t
+	add_to_userinfo            = %t
+	add_to_token_introspection = %t
+}`, testAccRealm.Realm, mapper.ClientId, mapper.Name, mapper.ClaimName, mapper.FullPath, mapper.AddToIdToken, mapper.AddToAccessToken, mapper.AddToUserinfo, mapper.AddToTokenIntrospection)
+}
+
+func TestAccKeycloakOpenIdGroupMembershipProtocolMapper_addToTokenIntrospection(t *testing.T) {
+	t.Parallel()
+	clientId := acctest.RandomWithPrefix("tf-acc")
+	mapperName := acctest.RandomWithPrefix("tf-acc")
+
+	resourceName := "keycloak_openid_group_membership_protocol_mapper.group_membership_mapper_client"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccKeycloakOpenIdGroupMembershipProtocolMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenIdGroupMembershipProtocolMapper_addToTokenIntrospection(clientId, mapperName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakOpenIdGroupMembershipProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_to_token_introspection", "false"),
+				),
+			},
+			{
+				Config: testKeycloakOpenIdGroupMembershipProtocolMapper_addToTokenIntrospection(clientId, mapperName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakOpenIdGroupMembershipProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "add_to_token_introspection", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testKeycloakOpenIdGroupMembershipProtocolMapper_addToTokenIntrospection(clientId, mapperName string, addToTokenIntrospection bool) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "openid_client" {
+	realm_id    = data.keycloak_realm.realm.id
+	client_id   = "%s"
+
+	access_type = "BEARER-ONLY"
+}
+
+resource "keycloak_openid_group_membership_protocol_mapper" "group_membership_mapper_client" {
+	name                       = "%s"
+	realm_id                   = data.keycloak_realm.realm.id
+	client_id                  = "${keycloak_openid_client.openid_client.id}"
+	claim_name                 = "bar"
+	add_to_token_introspection = %t
+}`, testAccRealm.Realm, clientId, mapperName, addToTokenIntrospection)
 }
 
 func testKeycloakOpenIdGroupMembershipProtocolMapper_updateClientForceNew(clientIdOne, clientIdTwo, currentClient string) string {


### PR DESCRIPTION
Adds `add_to_token_introspection` option to `keycloak_openid_group_membership_protocol_mapper` and `keycloak_openid_audience_protocol_mapper`.