### PR TITLE
feat: support include_in_openid_provider_metadata for openid client scope

### DIFF
--- a/docs/resources/openid_client_scope.md
+++ b/docs/resources/openid_client_scope.md
@@ -18,11 +18,12 @@ resource "keycloak_realm" "realm" {
 }
 
 resource "keycloak_openid_client_scope" "openid_client_scope" {
-  realm_id               = keycloak_realm.realm.id
-  name                   = "groups"
-  description            = "When requested, this scope will map a user's group memberships to a claim"
-  include_in_token_scope = true
-  gui_order              = 1
+  realm_id                            = keycloak_realm.realm.id
+  name                                = "groups"
+  description                         = "When requested, this scope will map a user's group memberships to a claim"
+  include_in_token_scope              = true
+  include_in_openid_provider_metadata = true
+  gui_order                           = 1
 }
 ```
 
@@ -33,6 +34,7 @@ resource "keycloak_openid_client_scope" "openid_client_scope" {
 - `description` - (Optional) The description of this client scope in the GUI.
 - `consent_screen_text` - (Optional) When set, a consent screen will be displayed to users authenticating to clients with this scope attached. The consent screen will display the string value of this attribute.
 - `include_in_token_scope` - (Optional) When `true`, the name of this client scope will be added to the access token property 'scope' as well as to the Token Introspection Endpoint response. When `false`, this scope will be omitted from the token and from the Token Introspection Endpoint response. Defaults to `true`.
+- `include_in_openid_provider_metadata` - (Optional) When `true`, this client scope will be listed in the `scopes_supported` field of the realm's OpenID Provider Metadata (the `.well-known/openid-configuration` discovery document). When `false`, it will be omitted. Defaults to `true`.
 - `gui_order` - (Optional) Specify order of the client scope in GUI (such as in Consent page) as integer.
 - `extra_config` - (Optional) A map of key/value pairs to add extra configuration attributes to this client scope. This can be used for custom attributes or to add configuration attributes that are not yet supported by this Terraform provider. Use this attribute at your own risk, as it may conflict with top-level configuration attributes in future provider updates.
   ``` hcl

--- a/keycloak/openid_client_scope.go
+++ b/keycloak/openid_client_scope.go
@@ -18,11 +18,12 @@ type OpenidClientScope struct {
 }
 
 type OpenidClientScopeAttributes struct {
-	DisplayOnConsentScreen types.KeycloakBoolQuoted `json:"display.on.consent.screen"` // boolean in string form
-	ConsentScreenText      string                   `json:"consent.screen.text"`
-	GuiOrder               string                   `json:"gui.order"`
-	IncludeInTokenScope    types.KeycloakBoolQuoted `json:"include.in.token.scope"` // boolean in string form
-	ExtraConfig            map[string]interface{}   `json:"-"`
+	DisplayOnConsentScreen          types.KeycloakBoolQuoted `json:"display.on.consent.screen"` // boolean in string form
+	ConsentScreenText               string                   `json:"consent.screen.text"`
+	GuiOrder                        string                   `json:"gui.order"`
+	IncludeInTokenScope             types.KeycloakBoolQuoted `json:"include.in.token.scope"`              // boolean in string form
+	IncludeInOpenidProviderMetadata types.KeycloakBoolQuoted `json:"include.in.openid.provider.metadata"` // boolean in string form
+	ExtraConfig                     map[string]interface{}   `json:"-"`
 }
 
 type OpenidClientScopeFilterFunc func(*OpenidClientScope) bool

--- a/provider/data_source_keycloak_openid_client_scope.go
+++ b/provider/data_source_keycloak_openid_client_scope.go
@@ -33,6 +33,10 @@ func dataSourceKeycloakOpenidClientScope() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"include_in_openid_provider_metadata": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"gui_order": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/provider/resource_keycloak_openid_client_scope.go
+++ b/provider/resource_keycloak_openid_client_scope.go
@@ -47,6 +47,11 @@ func resourceKeycloakOpenidClientScope() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"include_in_openid_provider_metadata": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
 			"gui_order": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -83,6 +88,8 @@ func getOpenidClientScopeFromData(data *schema.ResourceData) *keycloak.OpenidCli
 
 	clientScope.Attributes.IncludeInTokenScope = types.KeycloakBoolQuoted(data.Get("include_in_token_scope").(bool))
 
+	clientScope.Attributes.IncludeInOpenidProviderMetadata = types.KeycloakBoolQuoted(data.Get("include_in_openid_provider_metadata").(bool))
+
 	// Treat 0 as an empty string for the purpose of omitting the attribute to reset the order
 	if guiOrder := data.Get("gui_order").(int); guiOrder != 0 {
 		clientScope.Attributes.GuiOrder = strconv.Itoa(guiOrder)
@@ -105,6 +112,7 @@ func setOpenidClientScopeData(data *schema.ResourceData, clientScope *keycloak.O
 	}
 
 	data.Set("include_in_token_scope", clientScope.Attributes.IncludeInTokenScope)
+	data.Set("include_in_openid_provider_metadata", clientScope.Attributes.IncludeInOpenidProviderMetadata)
 	if guiOrder, err := strconv.Atoi(clientScope.Attributes.GuiOrder); err == nil {
 		data.Set("gui_order", guiOrder)
 	}

--- a/provider/resource_keycloak_openid_client_scope_test.go
+++ b/provider/resource_keycloak_openid_client_scope_test.go
@@ -149,6 +149,35 @@ func TestAccKeycloakClientScope_includeInTokenScope(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakClientScope_includeInOpenidProviderMetadata(t *testing.T) {
+	t.Parallel()
+	clientScopeName := acctest.RandomWithPrefix("tf-acc")
+	includeInOpenidProviderMetadata := false
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakClientScopeDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakClientScope_basic(clientScopeName),
+				Check:  testAccCheckKeycloakClientScopeExistsWithCorrectProtocol("keycloak_openid_client_scope.client_scope"),
+			},
+			{
+				Config: testKeycloakClientScope_withIncludeInOpenidProviderMetadata(clientScopeName, includeInOpenidProviderMetadata),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakClientScopeExistsWithCorrectProtocol("keycloak_openid_client_scope.client_scope"),
+					testAccCheckKeycloakClientScopeExistsWithCorrectIncludeInOpenidProviderMetadata("keycloak_openid_client_scope.client_scope", includeInOpenidProviderMetadata),
+				),
+			},
+			{
+				Config: testKeycloakClientScope_basic(clientScopeName),
+				Check:  testAccCheckKeycloakClientScopeExistsWithCorrectProtocol("keycloak_openid_client_scope.client_scope"),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakClientScope_guiOrder(t *testing.T) {
 	t.Parallel()
 	clientScopeName := acctest.RandomWithPrefix("tf-acc")
@@ -236,6 +265,21 @@ func testAccCheckKeycloakClientScopeExistsWithCorrectIncludeInTokenScope(resourc
 
 		if clientScope.Attributes.IncludeInTokenScope != types.KeycloakBoolQuoted(includeInTokenScope) {
 			return fmt.Errorf("expected saml client includeInTokenScope to have %t, but got %t", includeInTokenScope, clientScope.Attributes.IncludeInTokenScope)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKeycloakClientScopeExistsWithCorrectIncludeInOpenidProviderMetadata(resourceName string, includeInOpenidProviderMetadata bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		clientScope, err := getClientScopeFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if clientScope.Attributes.IncludeInOpenidProviderMetadata != types.KeycloakBoolQuoted(includeInOpenidProviderMetadata) {
+			return fmt.Errorf("expected openid client scope includeInOpenidProviderMetadata to have %t, but got %t", includeInOpenidProviderMetadata, clientScope.Attributes.IncludeInOpenidProviderMetadata)
 		}
 
 		return nil
@@ -370,6 +414,23 @@ resource "keycloak_openid_client_scope" "client_scope" {
 	include_in_token_scope = %t
 }
 	`, testAccRealm.Realm, clientScopeName, includeInTokenScope)
+}
+
+func testKeycloakClientScope_withIncludeInOpenidProviderMetadata(clientScopeName string, includeInOpenidProviderMetadata bool) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client_scope" "client_scope" {
+	name                = "%s"
+	realm_id            = data.keycloak_realm.realm.id
+
+	description         = "test description"
+
+	include_in_openid_provider_metadata = %t
+}
+	`, testAccRealm.Realm, clientScopeName, includeInOpenidProviderMetadata)
 }
 
 func testKeycloakClientScope_withGuiOrder(clientScopeName string, guiOrder int) string {


### PR DESCRIPTION
Add the include_in_openid_provider_metadata attribute to the keycloak_openid_client_scope resource and data source, mapping to Keycloak's include.in.openid.provider.metadata client scope attribute. Controls whether the scope is listed in the realm's OpenID Provider Metadata (.well-known/openid-configuration). Defaults to true.

Includes acceptance test and docs.

Fixes #1632