### PR TITLE
fix: add the `idpEntityId` as a parameter for identity providers

### DIFF
--- a/docs/resources/saml_identity_provider.md
+++ b/docs/resources/saml_identity_provider.md
@@ -49,6 +49,7 @@ resource "keycloak_saml_identity_provider" "realm_saml_identity_provider" {
 - `post_broker_login_flow_alias` - (Optional) Alias of authentication flow, which is triggered after each login with this identity provider. Useful if you want additional verification of each user authenticated with this identity provider (for example OTP). Leave this empty if you don't want any additional authenticators to be triggered after login with this identity provider. Also note, that authenticator implementations must assume that user is already set in ClientSession as identity provider already set it. Defaults to empty.
 - `authenticate_by_default` - (Optional) Authenticate users by default. Defaults to `false`.
 - `entity_id` - (Required) The Entity ID that will be used to uniquely identify this SAML Service Provider.
+- `idp_entity_id` - (Optional) The Entity ID as reported by the identity provider.
 - `single_sign_on_service_url` - (Required) The Url that must be used to send authentication requests (SAML AuthnRequest).
 - `single_logout_service_url` - (Optional) The Url that must be used to send logout requests.
 - `backchannel_supported` - (Optional) Does the external IDP support backchannel logout?. Defaults to `false`.

--- a/keycloak/identity_provider.go
+++ b/keycloak/identity_provider.go
@@ -20,6 +20,7 @@ type IdentityProviderConfig struct {
 	UserInfoUrl                     string                    `json:"userInfoUrl,omitempty"`
 	NameIDPolicyFormat              string                    `json:"nameIDPolicyFormat,omitempty"`
 	EntityId                        string                    `json:"entityId,omitempty"`
+	IdpEntityId                     string                    `json:"idpEntityId,omitempty"`
 	SingleLogoutServiceUrl          string                    `json:"singleLogoutServiceUrl,omitempty"`
 	SingleSignOnServiceUrl          string                    `json:"singleSignOnServiceUrl,omitempty"`
 	SigningCertificate              string                    `json:"signingCertificate,omitempty"`

--- a/provider/resource_keycloak_saml_identity_provider.go
+++ b/provider/resource_keycloak_saml_identity_provider.go
@@ -90,6 +90,11 @@ func resourceKeycloakSamlIdentityProvider() *schema.Resource {
 			Required:    true,
 			Description: "The Entity ID that will be used to uniquely identify this SAML Service Provider.",
 		},
+		"idp_entity_id": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The Entity ID provided by the identity provider.",
+		},
 		"single_sign_on_service_url": {
 			Type:        schema.TypeString,
 			Required:    true,
@@ -214,6 +219,7 @@ func getSamlIdentityProviderFromData(data *schema.ResourceData, keycloakVersion 
 		BackchannelSupported:            types.KeycloakBoolQuoted(data.Get("backchannel_supported").(bool)),
 		NameIDPolicyFormat:              nameIdPolicyFormats[data.Get("name_id_policy_format").(string)],
 		EntityId:                        data.Get("entity_id").(string),
+		IdpEntityId:                     data.Get("idp_entity_id").(string),
 		SingleLogoutServiceUrl:          data.Get("single_logout_service_url").(string),
 		SingleSignOnServiceUrl:          data.Get("single_sign_on_service_url").(string),
 		SigningCertificate:              data.Get("signing_certificate").(string),
@@ -270,6 +276,7 @@ func setSamlIdentityProviderData(data *schema.ResourceData, identityProvider *ke
 	data.Set("validate_signature", identityProvider.Config.ValidateSignature)
 	data.Set("name_id_policy_format", nameIDPolicyFormat)
 	data.Set("entity_id", identityProvider.Config.EntityId)
+	data.Set("idp_entity_id", identityProvider.Config.IdpEntityId)
 	data.Set("single_logout_service_url", identityProvider.Config.SingleLogoutServiceUrl)
 	data.Set("single_sign_on_service_url", identityProvider.Config.SingleSignOnServiceUrl)
 	data.Set("signing_certificate", identityProvider.Config.SigningCertificate)

--- a/provider/resource_keycloak_saml_identity_provider_test.go
+++ b/provider/resource_keycloak_saml_identity_provider_test.go
@@ -219,6 +219,7 @@ func TestAccKeycloakSamlIdentityProvider_basicUpdateAll(t *testing.T) {
 		HideOnLogin: firstHideOnLogin,
 		Config: &keycloak.IdentityProviderConfig{
 			EntityId:                        "https://example.com/entity_id/1",
+			IdpEntityId:                     "https://example.com/idp/entity_id/1",
 			SingleSignOnServiceUrl:          "https://example.com/signon/1",
 			BackchannelSupported:            types.KeycloakBoolQuoted(firstBackchannel),
 			ValidateSignature:               types.KeycloakBoolQuoted(firstValidateSignature),
@@ -249,6 +250,7 @@ func TestAccKeycloakSamlIdentityProvider_basicUpdateAll(t *testing.T) {
 		HideOnLogin: !firstHideOnLogin,
 		Config: &keycloak.IdentityProviderConfig{
 			EntityId:                        "https://example.com/entity_id/2",
+			IdpEntityId:                     "https://example.com/idp/entity_id/2",
 			SingleSignOnServiceUrl:          "https://example.com/signon/2",
 			BackchannelSupported:            types.KeycloakBoolQuoted(!firstBackchannel),
 			ValidateSignature:               types.KeycloakBoolQuoted(!firstValidateSignature),


### PR DESCRIPTION
Noted that the IdpEntityId was not included as an option when setting up the identity providers.