### PR TITLE
fix: gracefully handle 404 on delete for groups and users 

### DIFF
--- a/provider/resource_keycloak_group_memberships.go
+++ b/provider/resource_keycloak_group_memberships.go
@@ -129,7 +129,12 @@ func resourceKeycloakGroupMembershipsDelete(ctx context.Context, data *schema.Re
 	realmId := data.Get("realm_id").(string)
 	groupId := data.Get("group_id").(string)
 
-	return diag.FromErr(keycloakClient.RemoveUsersFromGroup(ctx, realmId, groupId, data.Get("members").(*schema.Set).List()))
+	err := keycloakClient.RemoveUsersFromGroup(ctx, realmId, groupId, data.Get("members").(*schema.Set).List())
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	return nil
 }
 
 func groupMembershipsId(realmId, groupId string) string {

--- a/provider/resource_keycloak_group_roles.go
+++ b/provider/resource_keycloak_group_roles.go
@@ -197,6 +197,9 @@ func resourceKeycloakGroupRolesDelete(ctx context.Context, data *schema.Resource
 	groupId := data.Get("group_id").(string)
 
 	group, err := keycloakClient.GetGroup(ctx, realmId, groupId)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
 
 	roleIds := interfaceSliceToStringSlice(data.Get("role_ids").(*schema.Set).List())
 	rolesToRemove, err := getExtendedRoleMapping(ctx, keycloakClient, realmId, roleIds)
@@ -206,7 +209,7 @@ func resourceKeycloakGroupRolesDelete(ctx context.Context, data *schema.Resource
 
 	err = removeRolesFromGroup(ctx, keycloakClient, rolesToRemove.clientRoles, rolesToRemove.realmRoles, group)
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(ctx, err, data)
 	}
 
 	return nil

--- a/provider/resource_keycloak_user_groups.go
+++ b/provider/resource_keycloak_user_groups.go
@@ -127,7 +127,12 @@ func resourceKeycloakUserGroupsDelete(ctx context.Context, data *schema.Resource
 	userId := data.Get("user_id").(string)
 	groupIds := interfaceSliceToStringSlice(data.Get("group_ids").(*schema.Set).List())
 
-	return diag.FromErr(keycloakClient.RemoveUserFromGroups(ctx, groupIds, userId, realmId))
+	err := keycloakClient.RemoveUserFromGroups(ctx, groupIds, userId, realmId)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	return nil
 }
 
 func resourceKeycloakUserGroupsImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/provider/resource_keycloak_user_roles.go
+++ b/provider/resource_keycloak_user_roles.go
@@ -197,6 +197,9 @@ func resourceKeycloakUserRolesDelete(ctx context.Context, data *schema.ResourceD
 	userId := data.Get("user_id").(string)
 
 	user, err := keycloakClient.GetUser(ctx, realmId, userId)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
 
 	roleIds := interfaceSliceToStringSlice(data.Get("role_ids").(*schema.Set).List())
 	rolesToRemove, err := getExtendedRoleMapping(ctx, keycloakClient, realmId, roleIds)
@@ -206,7 +209,7 @@ func resourceKeycloakUserRolesDelete(ctx context.Context, data *schema.ResourceD
 
 	err = removeRolesFromUser(ctx, keycloakClient, rolesToRemove.clientRoles, rolesToRemove.realmRoles, user)
 	if err != nil {
-		return diag.FromErr(err)
+		return handleNotFoundError(ctx, err, data)
 	}
 
 	return nil


### PR DESCRIPTION
Handle API 404 errors gracefully when deleting resources that represent user-group memberships, group-role mappings, user-group assignments, and user-role mappings. 

If the parent resource (the Realm, User, or Group) has already been deleted, these mappings do not exist anymore. 

Deleting them should succeed rather than failing or causing nil pointer dereferences/panics.