### PR TITLE
feat: add generic client authorization policy resource and restore keycloak_openid_client_js_policy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Build user-federation-example with Gradle
         run:  make user-federation-example
 
+      - name: Build authz-policy-example
+        run:  make authz-policy-example
+
       - name: Get Keycloak Version
         id: keycloak-version
         shell: bash
@@ -118,6 +121,7 @@ jobs:
           EXTRA_HTTPS_KEY=""
           EXTRA_MTLS_CERTS=""
           MOUNT_FEDERATION_EXAMPLE_VOLUME="-v $PWD/custom-user-federation-example/build/libs/custom-user-federation-example-all.jar:/opt/keycloak/providers/custom-user-federation-example-all.jar:z"
+          MOUNT_AUTHZ_POLICY_EXAMPLE_VOLUME="-v $PWD/custom-authz-policy-example/build/keycloak-authz-policy-example.jar:/opt/keycloak/providers/keycloak-authz-policy-example.jar:z"
           if [[ "$KC_26_2_OR_LATER" == "true" ]]; then
             # When fgap-version is set explicitly use it; otherwise default to v2
             # (the default since Keycloak 26.2). The feature must be enabled
@@ -147,6 +151,7 @@ jobs:
           -e KC_FEATURES=preview${EXTRA_FEATURES} \
           -v $PWD/provider/testdata:/opt/keycloak/testdata:z \
           $MOUNT_FEDERATION_EXAMPLE_VOLUME \
+          $MOUNT_AUTHZ_POLICY_EXAMPLE_VOLUME \
           quay.io/keycloak/keycloak:${{ matrix.keycloak-version }} --verbose start-dev
 
       - name: Initialize Keycloak

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ custom-user-federation-example/bin
 custom-user-federation-example/build
 !custom-user-federation-example/build/libs
 
+# custom authz policy example
+custom-authz-policy-example/build
+
 # docs
 site/
 

--- a/custom-authz-policy-example/META-INF/keycloak-scripts.json
+++ b/custom-authz-policy-example/META-INF/keycloak-scripts.json
@@ -1,0 +1,9 @@
+{
+  "policies": [
+    {
+      "name": "Always Granting Policy",
+      "fileName": "always-granting-policy.js",
+      "description": "A deployed JavaScript authorization policy used by the terraform-provider-keycloak acceptance tests"
+    }
+  ]
+}

--- a/custom-authz-policy-example/README.md
+++ b/custom-authz-policy-example/README.md
@@ -1,0 +1,29 @@
+# custom-authz-policy-example
+
+A minimal Keycloak provider JAR that deploys a JavaScript authorization policy via a
+`META-INF/keycloak-scripts.json` descriptor. It exists so the acceptance tests for the
+`keycloak_generic_client_authorization_policy` resource have a real JAR-deployed policy
+provider to reference.
+
+Modern Keycloak versions no longer allow uploading the JavaScript code of an authorization
+policy through the API, so a deployed script is the only way to create such a policy.
+
+## Layout
+
+- `META-INF/keycloak-scripts.json` — descriptor declaring the deployed policy.
+- `always-granting-policy.js` — the policy code.
+
+After deployment the policy is available as a policy provider of type
+`script-always-granting-policy.js` (the `script-` prefix plus the descriptor `fileName`).
+
+## Building
+
+A scripts provider is just a JAR (a ZIP). Build it with:
+
+```sh
+make authz-policy-example
+```
+
+This produces `build/keycloak-authz-policy-example.jar`, which the local Keycloak
+(`docker-compose.yml`) and CI mount into `/opt/keycloak/providers/`. The `scripts`
+feature must be enabled (it is part of `KC_FEATURES=preview`).

--- a/custom-authz-policy-example/always-granting-policy.js
+++ b/custom-authz-policy-example/always-granting-policy.js
@@ -1,0 +1,4 @@
+// An always-granting JavaScript authorization policy used by the terraform-provider-keycloak
+// acceptance tests. Once deployed (in a JAR with META-INF/keycloak-scripts.json) it is
+// referenced as a policy of type "script-always-granting-policy.js".
+$evaluation.grant();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,4 +46,7 @@ services:
     volumes:
 # Make the custom-user-federation-example extension available to Keycloak. The :z option is required and tells Docker that the volume content will be shared between containers.
     - ./custom-user-federation-example/build/libs/custom-user-federation-example-all.jar:/opt/keycloak/providers/custom-user-federation-example-all.jar:z
+# Make the deployed JavaScript authorization policy available to Keycloak (used by the
+# keycloak_generic_client_authorization_policy acceptance test). Build it with `make authz-policy-example`.
+    - ./custom-authz-policy-example/build/keycloak-authz-policy-example.jar:/opt/keycloak/providers/keycloak-authz-policy-example.jar:z
     - ./provider/testdata:/opt/keycloak/testdata:z

--- a/docs/resources/generic_client_authorization_policy.md
+++ b/docs/resources/generic_client_authorization_policy.md
@@ -1,0 +1,103 @@
+---
+page_title: "keycloak_generic_client_authorization_policy Resource"
+---
+
+# keycloak\_generic\_client\_authorization\_policy Resource
+
+Allows you to manage a Keycloak client authorization policy of any provider type by referencing that
+provider by its `type`. This is the policy equivalent of `keycloak_generic_role_mapper` /
+`keycloak_generic_protocol_mapper`: it works with any policy provider registered in Keycloak, including
+custom providers you implement yourself.
+
+This is intended for custom policy providers that are deployed to Keycloak as a JAR. The `type` is simply
+the provider id that the policy's
+[`PolicyProviderFactory`](https://www.keycloak.org/docs-api/latest/javadocs/org/keycloak/authorization/policy/provider/PolicyProviderFactory.html)
+exposes via `getId()`:
+
+- For a policy implemented in Java as an SPI, `type` is whatever your `PolicyProviderFactory.getId()` returns.
+- For a [JavaScript policy](https://www.keycloak.org/docs/latest/authorization_services/index.html#_policy_js)
+  deployed as a script (in a JAR with a `META-INF/keycloak-scripts.json` descriptor), Keycloak generates the
+  provider id for you as `script-` followed by the `fileName` from the descriptor (if the `fileName`
+  contains a path, it is kept). The `script-` prefix is an implementation detail of the scripting SPI, not a
+  requirement of this resource. For example, `"fileName": "my-policy.js"` is referenced as
+  `type = "script-my-policy.js"`.
+  (Modern Keycloak no longer allows uploading the JavaScript code through the API, so the script must be
+  deployed alongside Keycloak and only referenced here.)
+
+For the policy types that ship with Keycloak (role, group, user, client, time, regex, ...) prefer the
+dedicated resources, e.g. `keycloak_openid_client_role_policy`.
+
+## Example Usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+resource "keycloak_openid_client" "test" {
+  client_id                = "client_id"
+  realm_id                 = keycloak_realm.realm.id
+  access_type              = "CONFIDENTIAL"
+  service_accounts_enabled = true
+
+  authorization {
+    policy_enforcement_mode = "ENFORCING"
+  }
+}
+
+# References a custom policy provider implemented in Java and deployed as a JAR.
+# "type" is the id returned by your PolicyProviderFactory.getId().
+resource "keycloak_generic_client_authorization_policy" "custom" {
+  resource_server_id = keycloak_openid_client.test.resource_server_id
+  realm_id           = keycloak_realm.realm.id
+  name               = "my-custom-policy"
+  type               = "my-custom-policy-provider"
+  decision_strategy  = "UNANIMOUS"
+  logic              = "POSITIVE"
+  description        = "Authorization policy backed by a custom Java SPI provider"
+}
+
+# References a JavaScript policy deployed as a script. Here Keycloak generates the
+# type as "script-" + the fileName from META-INF/keycloak-scripts.json.
+resource "keycloak_generic_client_authorization_policy" "deployed_js" {
+  resource_server_id = keycloak_openid_client.test.resource_server_id
+  realm_id           = keycloak_realm.realm.id
+  name               = "deployed-js-policy"
+  type               = "script-my-policy.js"
+  decision_strategy  = "UNANIMOUS"
+  logic              = "POSITIVE"
+  description        = "Authorization policy backed by a deployed JavaScript script"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `realm_id` - (Required) The realm this policy exists in.
+- `resource_server_id` - (Required) The ID of the resource server this policy is attached to.
+- `name` - (Required) The name of the policy.
+- `type` - (Required) The provider type of the policy, i.e. the id returned by the policy's
+  `PolicyProviderFactory.getId()`. For a custom Java SPI this is whatever id your factory exposes; for a
+  JavaScript policy deployed as a script it is `script-` followed by the `fileName` declared in
+  `META-INF/keycloak-scripts.json`, e.g. `script-my-policy.js`.
+- `decision_strategy` - (Required) The decision strategy, can be one of `UNANIMOUS`, `AFFIRMATIVE`, or `CONSENSUS`.
+- `logic` - (Optional) The logic, can be one of `POSITIVE` or `NEGATIVE`. Defaults to `POSITIVE`.
+- `description` - (Optional) A description for the authorization policy.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+- `id` - Policy ID representing the policy.
+
+## Import
+
+This resource can be imported using the format: `{{realmId}}/{{resourceServerId}}/{{policyId}}`.
+
+Example:
+
+```bash
+$ terraform import keycloak_generic_client_authorization_policy.deployed_js my-realm/3bd4a686-1062-4b59-97b8-e4e3f10b99da/63b3cde8-987d-4cd9-9306-1955579281d9
+```

--- a/docs/resources/openid_client_js_policy.md
+++ b/docs/resources/openid_client_js_policy.md
@@ -1,0 +1,76 @@
+---
+page_title: "keycloak_openid_client_js_policy Resource"
+---
+
+# keycloak\_openid\_client\_js\_policy Resource
+
+~> **Note:** Consider [`keycloak_generic_client_authorization_policy`](generic_client_authorization_policy.md) instead — it references deployed (and custom Java SPI) policy providers by `type` and does not suffer from the `code` drift described below.
+
+Allows you to manage JavaScript authorization policies.
+
+Modern Keycloak no longer allows uploading the JavaScript code of a policy through the API — the inline `upload_scripts` feature was removed in Keycloak 18, which is no longer supported by this provider. JavaScript policies must therefore be [deployed as a script](https://www.keycloak.org/docs/latest/authorization_services/index.html#_policy_js) (a JAR with a `META-INF/keycloak-scripts.json` descriptor); this resource can then reference the deployed policy. Accordingly, `code` must be set to the deployed provider id that Keycloak assigns to the script, which is `script-` followed by the `fileName` from the descriptor (e.g. `script-my-policy.js`).
+
+~> **Note:** On read, Keycloak returns the script's source in `code` rather than the provider id it was created with, which produces a permanent diff. Use `lifecycle { ignore_changes = [code] }` to suppress it (see the example below). The replacement resource does not have this problem.
+
+## Example Usage
+
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+resource "keycloak_openid_client" "test" {
+  client_id                = "client_id"
+  realm_id                 = keycloak_realm.realm.id
+  access_type              = "CONFIDENTIAL"
+  service_accounts_enabled = true
+  authorization {
+    policy_enforcement_mode = "ENFORCING"
+  }
+}
+
+resource "keycloak_openid_client_js_policy" "test" {
+  resource_server_id = keycloak_openid_client.test.resource_server_id
+  realm_id           = keycloak_realm.realm.id
+  name               = "js_policy"
+  decision_strategy  = "UNANIMOUS"
+  logic              = "POSITIVE"
+  # The deployed provider id: "script-" + the fileName from META-INF/keycloak-scripts.json.
+  code = "script-my-policy.js"
+
+  lifecycle {
+    # Keycloak returns the script source in "code" on read; ignore that drift.
+    ignore_changes = [code]
+  }
+}
+```
+
+### Argument Reference
+
+The following arguments are supported:
+
+- `realm_id` - (Required) The realm this policy exists in.
+- `resource_server_id` - (Required) The ID of the resource server.
+- `name` - (Required) The name of the policy.
+- `decision_strategy` - (Required) The decision strategy, can be one of `UNANIMOUS`, `AFFIRMATIVE`, or `CONSENSUS`.
+- `code` - (Required) The deployed JavaScript policy provider id, i.e. `script-` followed by the `fileName` declared in `META-INF/keycloak-scripts.json` (e.g. `script-my-policy.js`). Combine with `lifecycle { ignore_changes = [code] }` since Keycloak returns the script source on read.
+- `logic` - (Optional) The logic, can be one of `POSITIVE` or `NEGATIVE`. Defaults to `POSITIVE`.
+- `type` - (Optional) The type of the policy. Defaults to `js`.
+- `description` - (Optional) A description for the authorization policy.
+
+### Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+- `id` - Policy ID representing the JavaScript policy.
+
+## Import
+
+JavaScript policies can be imported using the format: `{{realmId}}/{{resourceServerId}}/{{policyId}}`.
+
+Example:
+
+```bash
+$ terraform import keycloak_openid_client_js_policy.test my-realm/3bd4a686-1062-4b59-97b8-e4e3f10b99da/63b3cde8-987d-4cd9-9306-1955579281d9
+```

--- a/keycloak/generic_client_authorization_policy.go
+++ b/keycloak/generic_client_authorization_policy.go
@@ -1,0 +1,55 @@
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type GenericClientAuthorizationPolicy struct {
+	Id               string `json:"id,omitempty"`
+	RealmId          string `json:"-"`
+	ResourceServerId string `json:"-"`
+	Name             string `json:"name"`
+	DecisionStrategy string `json:"decisionStrategy"`
+	Logic            string `json:"logic"`
+	Type             string `json:"type"`
+	Description      string `json:"description"`
+}
+
+func (keycloakClient *KeycloakClient) NewGenericClientAuthorizationPolicy(ctx context.Context, policy *GenericClientAuthorizationPolicy) error {
+	// The generic policy endpoint resolves the provider from the "type" field in the body. This is
+	// required for JAR-deployed policy providers (e.g. deployed JavaScript policies), whose type is
+	// "script-<fileName>" and may contain characters such as "/" that cannot be put in the URL path.
+	body, _, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy", policy.RealmId, policy.ResourceServerId), policy)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(body, &policy)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (keycloakClient *KeycloakClient) UpdateGenericClientAuthorizationPolicy(ctx context.Context, policy *GenericClientAuthorizationPolicy) error {
+	return keycloakClient.put(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/%s", policy.RealmId, policy.ResourceServerId, policy.Id), policy)
+}
+
+func (keycloakClient *KeycloakClient) DeleteGenericClientAuthorizationPolicy(ctx context.Context, realmId, resourceServerId, policyId string) error {
+	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/%s", realmId, resourceServerId, policyId), nil)
+}
+
+func (keycloakClient *KeycloakClient) GetGenericClientAuthorizationPolicy(ctx context.Context, realmId, resourceServerId, policyId string) (*GenericClientAuthorizationPolicy, error) {
+	policy := GenericClientAuthorizationPolicy{
+		Id:               policyId,
+		ResourceServerId: resourceServerId,
+		RealmId:          realmId,
+	}
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/%s", realmId, resourceServerId, policyId), &policy, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &policy, nil
+}

--- a/keycloak/openid_client_authorization_js_policy.go
+++ b/keycloak/openid_client_authorization_js_policy.go
@@ -1,0 +1,61 @@
+package keycloak
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type OpenidClientAuthorizationJSPolicy struct {
+	Id               string `json:"id,omitempty"`
+	RealmId          string `json:"-"`
+	ResourceServerId string `json:"-"`
+	Name             string `json:"name"`
+	DecisionStrategy string `json:"decisionStrategy"`
+	Logic            string `json:"logic"`
+	Type             string `json:"type"`
+	Code             string `json:"code"`
+	Description      string `json:"description"`
+}
+
+func (keycloakClient *KeycloakClient) NewOpenidClientAuthorizationJSPolicy(ctx context.Context, policy *OpenidClientAuthorizationJSPolicy) error {
+	// Only deployed script policies are supported: "code" is the deployed provider id (the
+	// "script-<fileName>" Keycloak assigns to a script deployed via a JAR). Inline JavaScript
+	// upload was removed in Keycloak 18, which is no longer supported by this provider.
+	body, _, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/%s", policy.RealmId, policy.ResourceServerId, policy.Code), policy)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(body, &policy)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (keycloakClient *KeycloakClient) UpdateOpenidClientAuthorizationJSPolicy(ctx context.Context, policy *OpenidClientAuthorizationJSPolicy) error {
+	err := keycloakClient.put(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/js/%s", policy.RealmId, policy.ResourceServerId, policy.Id), policy)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (keycloakClient *KeycloakClient) DeleteOpenidClientAuthorizationJSPolicy(ctx context.Context, realmId, resourceServerId, policyId string) error {
+	return keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/js/%s", realmId, resourceServerId, policyId), nil)
+}
+
+func (keycloakClient *KeycloakClient) GetOpenidClientAuthorizationJSPolicy(ctx context.Context, realmId, resourceServerId, policyId string) (*OpenidClientAuthorizationJSPolicy, error) {
+
+	policy := OpenidClientAuthorizationJSPolicy{
+		Id:               policyId,
+		ResourceServerId: resourceServerId,
+		RealmId:          realmId,
+	}
+	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/clients/%s/authz/resource-server/policy/js/%s", realmId, resourceServerId, policyId), &policy, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &policy, nil
+}

--- a/makefile
+++ b/makefile
@@ -35,13 +35,13 @@ run-debug:
 	echo "Starting delve debugger listening on port 127.0.0.1:58772"
 	dlv exec --listen=:58772 --accept-multiclient --headless "./terraform-provider-keycloak_$(VERSION)" -- -debug
 
-local: deps user-federation-example
+local: deps user-federation-example authz-policy-example
 	echo "Starting local Keycloak environment"
 	docker compose up --build -d
 	./scripts/wait-for-local-keycloak.sh
 	./scripts/create-terraform-client.sh
 
-local-mtls: deps user-federation-example
+local-mtls: deps user-federation-example authz-policy-example
 	echo "Starting local Keycloak environment with mtls"
 	docker compose --file docker-compose.yml --file docker-compose-mtls.yml up --build -d
 	./scripts/wait-for-local-keycloak.sh
@@ -83,6 +83,14 @@ access-token:
 
 user-federation-example:
 	cd custom-user-federation-example && ./gradlew shadowJar
+
+# Build a Keycloak provider JAR that deploys a JavaScript authorization policy. A scripts
+# provider is just a JAR (a ZIP) containing META-INF/keycloak-scripts.json and the scripts.
+# Used by the keycloak_generic_client_authorization_policy acceptance test.
+authz-policy-example:
+	rm -rf custom-authz-policy-example/build
+	mkdir -p custom-authz-policy-example/build
+	cd custom-authz-policy-example && zip -r -X build/keycloak-authz-policy-example.jar META-INF always-granting-policy.js
 
 mtls-certs:
 	./mtls-certs.sh create "$(CERTS_TLS_DIR)"

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -124,6 +124,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 			"keycloak_openid_client_user_policy":                         resourceKeycloakOpenidClientAuthorizationUserPolicy(),
 			"keycloak_openid_client_client_policy":                       resourceKeycloakOpenidClientAuthorizationClientPolicy(),
 			"keycloak_openid_client_regex_policy":                        resourceKeycloakOpenidClientAuthorizationRegexPolicy(),
+			"keycloak_openid_client_js_policy":                           resourceKeycloakOpenidClientAuthorizationJSPolicy(),
 			"keycloak_openid_client_authorization_client_scope_policy":   resourceKeycloakOpenidClientAuthorizationClientScopePolicy(),
 			"keycloak_openid_client_authorization_scope":                 resourceKeycloakOpenidClientAuthorizationScope(),
 			"keycloak_openid_client_authorization_permission":            resourceKeycloakOpenidClientAuthorizationPermission(),

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -93,6 +93,7 @@ func KeycloakProvider(client *keycloak.KeycloakClient) *schema.Provider {
 			"keycloak_saml_client":                                       resourceKeycloakSamlClient(),
 			"keycloak_saml_client_scope":                                 resourceKeycloakSamlClientScope(),
 			"keycloak_saml_client_default_scopes":                        resourceKeycloakSamlClientDefaultScopes(),
+			"keycloak_generic_client_authorization_policy":               resourceKeycloakGenericClientAuthorizationPolicy(),
 			"keycloak_generic_client_protocol_mapper":                    resourceKeycloakGenericClientProtocolMapper(),
 			"keycloak_generic_client_role_mapper":                        resourceKeycloakGenericClientRoleMapper(),
 			"keycloak_generic_protocol_mapper":                           resourceKeycloakGenericProtocolMapper(),

--- a/provider/resource_keycloak_generic_client_authorization_policy.go
+++ b/provider/resource_keycloak_generic_client_authorization_policy.go
@@ -1,0 +1,138 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakGenericClientAuthorizationPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKeycloakGenericClientAuthorizationPolicyCreate,
+		ReadContext:   resourceKeycloakGenericClientAuthorizationPolicyRead,
+		DeleteContext: resourceKeycloakGenericClientAuthorizationPolicyDelete,
+		UpdateContext: resourceKeycloakGenericClientAuthorizationPolicyUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: genericResourcePolicyImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"resource_server_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"decision_strategy": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"logic": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(keycloakPolicyLogicTypes, false),
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func getGenericClientAuthorizationPolicyFromData(data *schema.ResourceData) *keycloak.GenericClientAuthorizationPolicy {
+	return &keycloak.GenericClientAuthorizationPolicy{
+		Id:               data.Id(),
+		ResourceServerId: data.Get("resource_server_id").(string),
+		RealmId:          data.Get("realm_id").(string),
+		DecisionStrategy: data.Get("decision_strategy").(string),
+		Logic:            data.Get("logic").(string),
+		Name:             data.Get("name").(string),
+		Type:             data.Get("type").(string),
+		Description:      data.Get("description").(string),
+	}
+}
+
+func setGenericClientAuthorizationPolicyData(data *schema.ResourceData, policy *keycloak.GenericClientAuthorizationPolicy) {
+	data.SetId(policy.Id)
+
+	data.Set("resource_server_id", policy.ResourceServerId)
+	data.Set("realm_id", policy.RealmId)
+	data.Set("name", policy.Name)
+	data.Set("type", policy.Type)
+	data.Set("decision_strategy", policy.DecisionStrategy)
+	data.Set("logic", policy.Logic)
+	data.Set("description", policy.Description)
+}
+
+func resourceKeycloakGenericClientAuthorizationPolicyCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	resource := getGenericClientAuthorizationPolicyFromData(data)
+
+	err := keycloakClient.NewGenericClientAuthorizationPolicy(ctx, resource)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	setGenericClientAuthorizationPolicyData(data, resource)
+
+	return resourceKeycloakGenericClientAuthorizationPolicyRead(ctx, data, meta)
+}
+
+func resourceKeycloakGenericClientAuthorizationPolicyRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	resourceServerId := data.Get("resource_server_id").(string)
+	id := data.Id()
+
+	resource, err := keycloakClient.GetGenericClientAuthorizationPolicy(ctx, realmId, resourceServerId, id)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	setGenericClientAuthorizationPolicyData(data, resource)
+
+	return nil
+}
+
+func resourceKeycloakGenericClientAuthorizationPolicyUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	resource := getGenericClientAuthorizationPolicyFromData(data)
+
+	err := keycloakClient.UpdateGenericClientAuthorizationPolicy(ctx, resource)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	setGenericClientAuthorizationPolicyData(data, resource)
+
+	return nil
+}
+
+func resourceKeycloakGenericClientAuthorizationPolicyDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	resourceServerId := data.Get("resource_server_id").(string)
+	id := data.Id()
+
+	return diag.FromErr(keycloakClient.DeleteGenericClientAuthorizationPolicy(ctx, realmId, resourceServerId, id))
+}

--- a/provider/resource_keycloak_generic_client_authorization_policy_test.go
+++ b/provider/resource_keycloak_generic_client_authorization_policy_test.go
@@ -1,0 +1,130 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func TestAccKeycloakGenericClientAuthorizationPolicy(t *testing.T) {
+	t.Parallel()
+
+	clientId := acctest.RandomWithPrefix("tf-acc")
+	policyName := acctest.RandomWithPrefix("tf-acc")
+	// The deployed JavaScript policy provided by custom-authz-policy-example. For deployed
+	// scripts Keycloak generates the type as "script-" + the fileName declared in
+	// META-INF/keycloak-scripts.json. A policy implemented as a Java SPI would instead use
+	// the provider id returned by its PolicyProviderFactory.getId().
+	policyType := "script-always-granting-policy.js"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testResourceKeycloakGenericClientAuthorizationPolicyDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceKeycloakGenericClientAuthorizationPolicy_basic(clientId, policyName, policyType),
+				Check:  testResourceKeycloakGenericClientAuthorizationPolicyExists("keycloak_generic_client_authorization_policy.test"),
+			},
+			{
+				ResourceName:      "keycloak_generic_client_authorization_policy.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: getResourceKeycloakGenericClientAuthorizationPolicyImportId("keycloak_generic_client_authorization_policy.test"),
+			},
+		},
+	})
+}
+
+func getResourceKeycloakGenericClientAuthorizationPolicyFromState(s *terraform.State, resourceName string) (*keycloak.GenericClientAuthorizationPolicy, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("resource not found: %s", resourceName)
+	}
+
+	realm := rs.Primary.Attributes["realm_id"]
+	resourceServerId := rs.Primary.Attributes["resource_server_id"]
+	policyId := rs.Primary.ID
+
+	policy, err := keycloakClient.GetGenericClientAuthorizationPolicy(testCtx, realm, resourceServerId, policyId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting generic client authorization policy with id %s: %s", policyId, err)
+	}
+
+	return policy, nil
+}
+
+func getResourceKeycloakGenericClientAuthorizationPolicyImportId(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		realm := rs.Primary.Attributes["realm_id"]
+		resourceServerId := rs.Primary.Attributes["resource_server_id"]
+		policyId := rs.Primary.ID
+
+		return fmt.Sprintf("%s/%s/%s", realm, resourceServerId, policyId), nil
+	}
+}
+
+func testResourceKeycloakGenericClientAuthorizationPolicyDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "keycloak_generic_client_authorization_policy" {
+				continue
+			}
+
+			realm := rs.Primary.Attributes["realm_id"]
+			resourceServerId := rs.Primary.Attributes["resource_server_id"]
+			policyId := rs.Primary.ID
+
+			policy, _ := keycloakClient.GetGenericClientAuthorizationPolicy(testCtx, realm, resourceServerId, policyId)
+			if policy != nil {
+				return fmt.Errorf("policy config with id %s still exists", policyId)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testResourceKeycloakGenericClientAuthorizationPolicyExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, err := getResourceKeycloakGenericClientAuthorizationPolicyFromState(s, resourceName)
+
+		return err
+	}
+}
+
+func testResourceKeycloakGenericClientAuthorizationPolicy_basic(clientId, policyName, policyType string) string {
+	return fmt.Sprintf(`
+	data "keycloak_realm" "realm" {
+		realm = "%s"
+	}
+
+	resource keycloak_openid_client test {
+		client_id                = "%s"
+		realm_id                 = data.keycloak_realm.realm.id
+		access_type              = "CONFIDENTIAL"
+		service_accounts_enabled = true
+		authorization {
+			policy_enforcement_mode = "ENFORCING"
+		}
+	}
+
+	resource keycloak_generic_client_authorization_policy test {
+		resource_server_id = keycloak_openid_client.test.resource_server_id
+		realm_id           = data.keycloak_realm.realm.id
+		name               = "%s"
+		type               = "%s"
+		decision_strategy  = "UNANIMOUS"
+		logic              = "POSITIVE"
+	}
+	`, testAccRealm.Realm, clientId, policyName, policyType)
+}

--- a/provider/resource_keycloak_openid_client_authorization_js_policy.go
+++ b/provider/resource_keycloak_openid_client_authorization_js_policy.go
@@ -1,0 +1,149 @@
+package provider
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func resourceKeycloakOpenidClientAuthorizationJSPolicy() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceKeycloakOpenidClientAuthorizationJSPolicyCreate,
+		ReadContext:   resourceKeycloakOpenidClientAuthorizationJSPolicyRead,
+		DeleteContext: resourceKeycloakOpenidClientAuthorizationJSPolicyDelete,
+		UpdateContext: resourceKeycloakOpenidClientAuthorizationJSPolicyUpdate,
+		Importer: &schema.ResourceImporter{
+			StateContext: genericResourcePolicyImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"resource_server_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"realm_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"decision_strategy": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"logic": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(keycloakPolicyLogicTypes, false),
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"code": {
+				Type:     schema.TypeString,
+				Required: true,
+				// Inline JavaScript can no longer be uploaded through the API, so "code" must
+				// reference a policy deployed as a script by its provider id ("script-<fileName>").
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile(`^script-\S+$`),
+					`must reference a policy deployed as a script by its provider id, e.g. "script-my-policy.js" ("script-" followed by the fileName from META-INF/keycloak-scripts.json). Inline JavaScript is no longer supported by Keycloak; deploy the script in a JAR and reference it here, or use keycloak_generic_client_authorization_policy`,
+				),
+			},
+		},
+	}
+}
+
+func getOpenidClientAuthorizationJSPolicyResourceFromData(data *schema.ResourceData) *keycloak.OpenidClientAuthorizationJSPolicy {
+
+	resource := keycloak.OpenidClientAuthorizationJSPolicy{
+		Id:               data.Id(),
+		ResourceServerId: data.Get("resource_server_id").(string),
+		RealmId:          data.Get("realm_id").(string),
+		DecisionStrategy: data.Get("decision_strategy").(string),
+		Logic:            data.Get("logic").(string),
+		Name:             data.Get("name").(string),
+		Type:             "js",
+		Code:             data.Get("code").(string),
+		Description:      data.Get("description").(string),
+	}
+	return &resource
+}
+
+func setOpenidClientAuthorizationJSPolicyResourceData(data *schema.ResourceData, policy *keycloak.OpenidClientAuthorizationJSPolicy) {
+	data.SetId(policy.Id)
+
+	data.Set("resource_server_id", policy.ResourceServerId)
+	data.Set("realm_id", policy.RealmId)
+	data.Set("name", policy.Name)
+	data.Set("decision_strategy", policy.DecisionStrategy)
+	data.Set("logic", policy.Logic)
+	data.Set("description", policy.Description)
+	data.Set("code", policy.Code)
+}
+
+func resourceKeycloakOpenidClientAuthorizationJSPolicyCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	resource := getOpenidClientAuthorizationJSPolicyResourceFromData(data)
+
+	err := keycloakClient.NewOpenidClientAuthorizationJSPolicy(ctx, resource)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	setOpenidClientAuthorizationJSPolicyResourceData(data, resource)
+
+	return resourceKeycloakOpenidClientAuthorizationJSPolicyRead(ctx, data, meta)
+}
+
+func resourceKeycloakOpenidClientAuthorizationJSPolicyRead(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	resourceServerId := data.Get("resource_server_id").(string)
+	id := data.Id()
+
+	resource, err := keycloakClient.GetOpenidClientAuthorizationJSPolicy(ctx, realmId, resourceServerId, id)
+	if err != nil {
+		return handleNotFoundError(ctx, err, data)
+	}
+
+	setOpenidClientAuthorizationJSPolicyResourceData(data, resource)
+
+	return nil
+}
+
+func resourceKeycloakOpenidClientAuthorizationJSPolicyUpdate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	resource := getOpenidClientAuthorizationJSPolicyResourceFromData(data)
+
+	err := keycloakClient.UpdateOpenidClientAuthorizationJSPolicy(ctx, resource)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	setOpenidClientAuthorizationJSPolicyResourceData(data, resource)
+
+	return nil
+}
+
+func resourceKeycloakOpenidClientAuthorizationJSPolicyDelete(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	keycloakClient := meta.(*keycloak.KeycloakClient)
+
+	realmId := data.Get("realm_id").(string)
+	resourceServerId := data.Get("resource_server_id").(string)
+	id := data.Id()
+
+	return diag.FromErr(keycloakClient.DeleteOpenidClientAuthorizationJSPolicy(ctx, realmId, resourceServerId, id))
+}

--- a/provider/resource_keycloak_openid_client_authorization_js_policy_test.go
+++ b/provider/resource_keycloak_openid_client_authorization_js_policy_test.go
@@ -1,0 +1,122 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func TestAccKeycloakOpenidClientAuthorizationJSPolicy(t *testing.T) {
+	t.Parallel()
+
+	clientId := acctest.RandomWithPrefix("tf-acc")
+	policyName := acctest.RandomWithPrefix("tf-acc")
+	// Modern Keycloak no longer allows uploading JavaScript code through the API, so this
+	// references the JavaScript policy deployed as a JAR by custom-authz-policy-example. Its
+	// deployed provider id is "script-" + the fileName from META-INF/keycloak-scripts.json.
+	code := "script-always-granting-policy.js"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testResourceKeycloakOpenidClientAuthorizationJSPolicyDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceKeycloakOpenidClientAuthorizationJSPolicy_basic(clientId, policyName, code, "initial description"),
+				Check:  testResourceKeycloakOpenidClientAuthorizationJSPolicyExists("keycloak_openid_client_js_policy.test"),
+			},
+			{
+				// Update a non-code attribute to exercise the PUT /policy/js/{id} endpoint.
+				Config: testResourceKeycloakOpenidClientAuthorizationJSPolicy_basic(clientId, policyName, code, "updated description"),
+				Check: resource.ComposeTestCheckFunc(
+					testResourceKeycloakOpenidClientAuthorizationJSPolicyExists("keycloak_openid_client_js_policy.test"),
+					resource.TestCheckResourceAttr("keycloak_openid_client_js_policy.test", "description", "updated description"),
+				),
+			},
+		},
+	})
+}
+
+func getResourceKeycloakOpenidClientAuthorizationJSPolicyFromState(s *terraform.State, resourceName string) (*keycloak.OpenidClientAuthorizationJSPolicy, error) {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("resource not found: %s", resourceName)
+	}
+
+	realm := rs.Primary.Attributes["realm_id"]
+	resourceServerId := rs.Primary.Attributes["resource_server_id"]
+	policyId := rs.Primary.ID
+
+	policy, err := keycloakClient.GetOpenidClientAuthorizationJSPolicy(testCtx, realm, resourceServerId, policyId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting openid client auth js policy config with alias %s: %s", resourceServerId, err)
+	}
+
+	return policy, nil
+}
+
+func testResourceKeycloakOpenidClientAuthorizationJSPolicyDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "keycloak_openid_client_js_policy" {
+				continue
+			}
+
+			realm := rs.Primary.Attributes["realm_id"]
+			resourceServerId := rs.Primary.Attributes["resource_server_id"]
+			policyId := rs.Primary.ID
+
+			policy, _ := keycloakClient.GetOpenidClientAuthorizationJSPolicy(testCtx, realm, resourceServerId, policyId)
+			if policy != nil {
+				return fmt.Errorf("policy config with id %s still exists", policyId)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testResourceKeycloakOpenidClientAuthorizationJSPolicyExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, err := getResourceKeycloakOpenidClientAuthorizationJSPolicyFromState(s, resourceName)
+
+		return err
+	}
+}
+
+func testResourceKeycloakOpenidClientAuthorizationJSPolicy_basic(clientId, policyName, code, description string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource keycloak_openid_client test {
+	client_id                = "%s"
+	realm_id                 = data.keycloak_realm.realm.id
+	access_type              = "CONFIDENTIAL"
+	service_accounts_enabled = true
+	authorization {
+		policy_enforcement_mode = "ENFORCING"
+	}
+}
+
+resource keycloak_openid_client_js_policy test {
+	resource_server_id = keycloak_openid_client.test.resource_server_id
+	realm_id           = data.keycloak_realm.realm.id
+	name               = "%s"
+	logic              = "POSITIVE"
+	decision_strategy  = "UNANIMOUS"
+	code               = "%s"
+	description        = "%s"
+
+	lifecycle {
+		# Keycloak returns the deployed script's source in "code" on read; ignore that drift.
+		ignore_changes = [code]
+	}
+}
+	`, testAccRealm.Realm, clientId, policyName, code, description)
+}


### PR DESCRIPTION
Fixes https://github.com/keycloak/terraform-provider-keycloak/issues/1638

`keycloak_openid_client_js_policy` was removed in v5.8.0 as part of dropping
support for old Keycloak versions, but that removal was not intentional —
deployed JavaScript authorization policies are still supported by Keycloak 26.
This PR addresses the regression in two ways.

## 1. New resource: `keycloak_generic_client_authorization_policy`

A generic authorization policy resource, in the spirit of the existing
`keycloak_generic_*` resources. It manages a client authorization policy of any
provider type by referencing that provider through the `type` attribute, so it
works with:

- custom policy providers implemented as a Java SPI (`type` is whatever the
  `PolicyProviderFactory.getId()` returns)
- JavaScript policies deployed as a script in a JAR (`type` is the
  `script-<fileName>` id Keycloak assigns to the deployed script)

This is the recommended, future-proof way to manage deployed and custom policy
providers. It has no `code` attribute, so it does not suffer from the read-back
drift the JS-specific resource has.

## 2. Restored resource: `keycloak_openid_client_js_policy`

Brought back so existing configurations keep working without a migration. Two
changes reflect current Keycloak behaviour:

- It now handles only deployed script policies. `code` must be the deployed
  provider id (`script-<fileName>`), and is validated as such. Inline
  JavaScript upload was removed in Keycloak 18, which is no longer supported by
  this provider.
- On read Keycloak returns the script source in `code`, so the docs and example
  show `lifecycle { ignore_changes = [code] }`. The resource is not marked
  deprecated, but its documentation points to
  `keycloak_generic_client_authorization_policy` as the better alternative.

## Testing

A minimal scripts provider JAR (`custom-authz-policy-example`) is added and
deployed into the local and CI Keycloak so both resources have a real
deployed-script policy to reference. Acceptance tests for both resources pass
against Keycloak 26.6.3, covering create, read, update, import, and the
deployed-script `code` handling.