### PR TITLE
feat: adds import mode for openid user attribute and user property protocol mappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 FEATURES:
 
 * feat: support import for `keycloak_realm_default_client_scopes` and `keycloak_realm_optional_client_scopes` using the realm id
+* feat: add import mode for `keycloak_openid_user_property_protocol_mapper`
+* feat: add import mode for `keycloak_openid_user_attribute_protocol_mapper`
 
 ## 5.8.0 (June 05, 2026)
 

--- a/docs/resources/openid_user_attribute_protocol_mapper.md
+++ b/docs/resources/openid_user_attribute_protocol_mapper.md
@@ -80,6 +80,15 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "user_attribute_mapper
 - `add_to_userinfo` - (Optional) Indicates if the attribute should be added as a claim to the UserInfo response body. Defaults to `true`.
 - `add_to_token_introspection` - (Optional) Indicates if the attribute should be added as a claim to the token introspection response. Defaults to `true`.
 - `aggregate_attributes`- (Optional) Indicates whether this attribute is a single value or an array of values. Defaults to `false`.
+- `import` - (Optional) When `true`, the provider looks up an existing mapper by `name` under the specified realm and client or client scope and updates it with the new configuration, overwriting any existing values. After the first apply, the resource behaves identically to one that was created normally, including deletion on `terraform destroy`.
+
+## Import Mode Behavior
+
+When `import = true`, this resource uses adopt-and-update behavior during creation:
+
+- The provider looks up an existing protocol mapper by `name` under the given `realm_id` and `client_id` or `client_scope_id`.
+- If a mapper is found, it will be imported and updated with the specified configuration. Schema defaults will overwrite existing configuration.
+- After the first apply, `import` has no further effect. The resource is fully managed by Terraform, including deletion on `terraform destroy`.
 
 ## Import
 

--- a/docs/resources/openid_user_property_protocol_mapper.md
+++ b/docs/resources/openid_user_property_protocol_mapper.md
@@ -78,6 +78,15 @@ resource "keycloak_openid_user_property_protocol_mapper" "user_property_mapper" 
 - `add_to_id_token` - (Optional) Indicates if the property should be added as a claim to the id token. Defaults to `true`.
 - `add_to_access_token` - (Optional) Indicates if the property should be added as a claim to the access token. Defaults to `true`.
 - `add_to_userinfo` - (Optional) Indicates if the property should be added as a claim to the UserInfo response body. Defaults to `true`.
+- `import` - (Optional) When `true`, the provider looks up an existing mapper by `name` under the specified realm and client or client scope and updates it with the new configuration, overwriting any existing values. After the first apply, the resource behaves identically to one that was created normally, including deletion on `terraform destroy`.
+
+## Import Mode Behavior
+
+When `import = true`, this resource uses adopt-and-update behavior during creation:
+
+- The provider looks up an existing protocol mapper by `name` under the given `realm_id` and `client_id` or `client_scope_id`.
+- If a mapper is found, it will be imported and updated with the specified configuration. Schema defaults will overwrite existing configuration.
+- After the first apply, `import` has no further effect. The resource is fully managed by Terraform, including deletion on `terraform destroy`.
 
 ## Import
 

--- a/keycloak/generic_protocol_mapper.go
+++ b/keycloak/generic_protocol_mapper.go
@@ -54,6 +54,30 @@ func (keycloakClient *KeycloakClient) GetGenericProtocolMappers(ctx context.Cont
 
 }
 
+func (keycloakClient *KeycloakClient) GetGenericProtocolMapperByName(ctx context.Context, realmId string, clientId string, clientScopeId string, name string) (*GenericProtocolMapper, error) {
+	foundMapper, err := keycloakClient.getProtocolMapperByName(ctx, realmId, clientId, clientScopeId, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if foundMapper == nil {
+		return nil, nil
+	}
+
+	genericProtocolMapper := &GenericProtocolMapper{
+		Id:             foundMapper.Id,
+		Name:           foundMapper.Name,
+		Protocol:       foundMapper.Protocol,
+		ProtocolMapper: foundMapper.ProtocolMapper,
+		Config:         foundMapper.Config,
+		RealmId:        realmId,
+		ClientId:       clientId,
+		ClientScopeId:  clientScopeId,
+	}
+
+	return genericProtocolMapper, nil
+}
+
 func (keycloakClient *KeycloakClient) GetGenericProtocolMapper(ctx context.Context, realmId string, clientId string, clientScopeId string, mapperId string) (*GenericProtocolMapper, error) {
 	var genericProtocolMapper GenericProtocolMapper
 
@@ -88,7 +112,7 @@ func (mapper *GenericProtocolMapper) Validate(ctx context.Context, keycloakClien
 		return fmt.Errorf("validation error: only one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/openid_audience_protocol_mapper.go
+++ b/keycloak/openid_audience_protocol_mapper.go
@@ -120,7 +120,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdAudienceProtocolMapper(ctx c
 		return fmt.Errorf("validation error: IncludedClientAudience and IncludedCustomAudience cannot both be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/openid_audience_resolve_protocol_mapper.go
+++ b/keycloak/openid_audience_resolve_protocol_mapper.go
@@ -72,7 +72,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdAudienceResolveProtocolMappe
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/openid_full_name_protocol_mapper.go
+++ b/keycloak/openid_full_name_protocol_mapper.go
@@ -100,7 +100,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdFullNameProtocolMapper(ctx c
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/openid_group_membership_protocol_mapper.go
+++ b/keycloak/openid_group_membership_protocol_mapper.go
@@ -120,7 +120,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdGroupMembershipProtocolMappe
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/openid_hardcoded_claim_protocol_mapper.go
+++ b/keycloak/openid_hardcoded_claim_protocol_mapper.go
@@ -111,7 +111,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdHardcodedClaimProtocolMapper
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/openid_hardcoded_role_protocol_mapper.go
+++ b/keycloak/openid_hardcoded_role_protocol_mapper.go
@@ -141,7 +141,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdHardcodedRoleProtocolMapper(
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/openid_sub_protocol_mapper.go
+++ b/keycloak/openid_sub_protocol_mapper.go
@@ -92,7 +92,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdSubProtocolMapper(ctx contex
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/openid_user_attribute_protocol_mapper.go
+++ b/keycloak/openid_user_attribute_protocol_mapper.go
@@ -109,6 +109,19 @@ func (keycloakClient *KeycloakClient) GetOpenIdUserAttributeProtocolMapper(ctx c
 	return protocolMapper.convertToOpenIdUserAttributeProtocolMapper(realmId, clientId, clientScopeId)
 }
 
+func (keycloakClient *KeycloakClient) GetOpenIdUserAttributeProtocolMapperByName(ctx context.Context, realmId, clientId, clientScopeId, name string) (*OpenIdUserAttributeProtocolMapper, error) {
+	foundMapper, err := keycloakClient.getProtocolMapperByName(ctx, realmId, clientId, clientScopeId, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if foundMapper == nil {
+		return nil, nil
+	}
+
+	return foundMapper.convertToOpenIdUserAttributeProtocolMapper(realmId, clientId, clientScopeId)
+}
+
 func (keycloakClient *KeycloakClient) DeleteOpenIdUserAttributeProtocolMapper(ctx context.Context, realmId, clientId, clientScopeId, mapperId string) error {
 	return keycloakClient.delete(ctx, individualProtocolMapperPath(realmId, clientId, clientScopeId, mapperId), nil)
 }
@@ -133,19 +146,13 @@ func (keycloakClient *KeycloakClient) UpdateOpenIdUserAttributeProtocolMapper(ct
 }
 
 func (keycloakClient *KeycloakClient) ValidateOpenIdUserAttributeProtocolMapper(ctx context.Context, mapper *OpenIdUserAttributeProtocolMapper) error {
-	if mapper.ClientId == "" && mapper.ClientScopeId == "" {
-		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
-	}
-
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	existingMapper, err := keycloakClient.getProtocolMapperByName(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId, mapper.Name)
 	if err != nil {
 		return err
 	}
 
-	for _, protocolMapper := range protocolMappers {
-		if protocolMapper.Name == mapper.Name && protocolMapper.Id != mapper.Id {
-			return fmt.Errorf("validation error: a protocol mapper with name %s already exists for this client", mapper.Name)
-		}
+	if existingMapper != nil && existingMapper.Id != mapper.Id {
+		return fmt.Errorf("validation error: a protocol mapper with name %s already exists for this client or client scope", mapper.Name)
 	}
 
 	return nil

--- a/keycloak/openid_user_client_role_protocol_mapper.go
+++ b/keycloak/openid_user_client_role_protocol_mapper.go
@@ -123,7 +123,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdUserClientRoleProtocolMapper
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/openid_user_property_protocol_mapper.go
+++ b/keycloak/openid_user_property_protocol_mapper.go
@@ -83,6 +83,19 @@ func (keycloakClient *KeycloakClient) GetOpenIdUserPropertyProtocolMapper(ctx co
 	return protocolMapper.convertToOpenIdUserPropertyProtocolMapper(realmId, clientId, clientScopeId)
 }
 
+func (keycloakClient *KeycloakClient) GetOpenIdUserPropertyProtocolMapperByName(ctx context.Context, realmId, clientId, clientScopeId, name string) (*OpenIdUserPropertyProtocolMapper, error) {
+	foundMapper, err := keycloakClient.getProtocolMapperByName(ctx, realmId, clientId, clientScopeId, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if foundMapper == nil {
+		return nil, nil
+	}
+
+	return foundMapper.convertToOpenIdUserPropertyProtocolMapper(realmId, clientId, clientScopeId)
+}
+
 func (keycloakClient *KeycloakClient) DeleteOpenIdUserPropertyProtocolMapper(ctx context.Context, realmId, clientId, clientScopeId, mapperId string) error {
 	return keycloakClient.delete(ctx, individualProtocolMapperPath(realmId, clientId, clientScopeId, mapperId), nil)
 }
@@ -107,19 +120,13 @@ func (keycloakClient *KeycloakClient) UpdateOpenIdUserPropertyProtocolMapper(ctx
 }
 
 func (mapper *OpenIdUserPropertyProtocolMapper) Validate(ctx context.Context, keycloakClient *KeycloakClient) error {
-	if mapper.ClientId == "" && mapper.ClientScopeId == "" {
-		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
-	}
-
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	existingMapper, err := keycloakClient.getProtocolMapperByName(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId, mapper.Name)
 	if err != nil {
 		return err
 	}
 
-	for _, protocolMapper := range protocolMappers {
-		if protocolMapper.Name == mapper.Name {
-			return fmt.Errorf("validation error: a protocol mapper with name %s already exists for this client", mapper.Name)
-		}
+	if existingMapper != nil && existingMapper.Id != mapper.Id {
+		return fmt.Errorf("validation error: a protocol mapper with name %s already exists for this client or client scope", mapper.Name)
 	}
 
 	return nil

--- a/keycloak/openid_user_realm_role_protocol_mapper.go
+++ b/keycloak/openid_user_realm_role_protocol_mapper.go
@@ -127,7 +127,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdUserRealmRoleProtocolMapper(
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/openid_user_session_note_protocol_mapper.go
+++ b/keycloak/openid_user_session_note_protocol_mapper.go
@@ -119,7 +119,7 @@ func (keycloakClient *KeycloakClient) ValidateOpenIdUserSessionNoteProtocolMappe
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/protocol_mapper.go
+++ b/keycloak/protocol_mapper.go
@@ -57,7 +57,7 @@ func individualProtocolMapperPath(realmId, clientId, clientScopeId, mapperId str
 	return fmt.Sprintf("%s/%s", protocolMapperPath(realmId, clientId, clientScopeId), mapperId)
 }
 
-func (keycloakClient *KeycloakClient) listGenericProtocolMappers(ctx context.Context, realmId, clientId, clientScopeId string) ([]*protocolMapper, error) {
+func (keycloakClient *KeycloakClient) listProtocolMappers(ctx context.Context, realmId, clientId, clientScopeId string) ([]*protocolMapper, error) {
 	var protocolMappers []*protocolMapper
 
 	err := keycloakClient.get(ctx, protocolMapperPath(realmId, clientId, clientScopeId), &protocolMappers, nil)
@@ -68,27 +68,17 @@ func (keycloakClient *KeycloakClient) listGenericProtocolMappers(ctx context.Con
 	return protocolMappers, nil
 }
 
-// ListGenericProtocolMappers returns all protocol mappers for a client or client scope.
-// Used by the data source to look up mappers by name.
-func (keycloakClient *KeycloakClient) ListGenericProtocolMappers(ctx context.Context, realmId, clientId, clientScopeId string) ([]*GenericProtocolMapper, error) {
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, realmId, clientId, clientScopeId)
+func (keycloakClient *KeycloakClient) getProtocolMapperByName(ctx context.Context, realmId, clientId, clientScopeId, name string) (*protocolMapper, error) {
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, realmId, clientId, clientScopeId)
 	if err != nil {
 		return nil, err
 	}
 
-	genericProtocolMappers := make([]*GenericProtocolMapper, len(protocolMappers))
-	for i, mapper := range protocolMappers {
-		genericProtocolMappers[i] = &GenericProtocolMapper{
-			Id:             mapper.Id,
-			Name:           mapper.Name,
-			Protocol:       mapper.Protocol,
-			ProtocolMapper: mapper.ProtocolMapper,
-			Config:         mapper.Config,
-			RealmId:        realmId,
-			ClientId:       clientId,
-			ClientScopeId:  clientScopeId,
+	for _, mapper := range protocolMappers {
+		if mapper.Name == name {
+			return mapper, nil
 		}
 	}
 
-	return genericProtocolMappers, nil
+	return nil, nil
 }

--- a/keycloak/saml_user_attribute_protocol_mapper.go
+++ b/keycloak/saml_user_attribute_protocol_mapper.go
@@ -96,7 +96,7 @@ func (keycloakClient *KeycloakClient) ValidateSamlUserAttributeProtocolMapper(ct
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/keycloak/saml_user_property_protocol_mapper.go
+++ b/keycloak/saml_user_property_protocol_mapper.go
@@ -87,7 +87,7 @@ func (keycloakClient *KeycloakClient) ValidateSamlUserPropertyProtocolMapper(ctx
 		return fmt.Errorf("validation error: one of ClientId or ClientScopeId must be set")
 	}
 
-	protocolMappers, err := keycloakClient.listGenericProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
+	protocolMappers, err := keycloakClient.listProtocolMappers(ctx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId)
 	if err != nil {
 		return err
 	}

--- a/provider/data_source_keycloak_generic_protocol_mapper.go
+++ b/provider/data_source_keycloak_generic_protocol_mapper.go
@@ -66,18 +66,9 @@ func dataSourceKeycloakGenericProtocolMapperRead(ctx context.Context, data *sche
 		return diag.Errorf("one of client_id or client_scope_id must be set")
 	}
 
-	// List all protocol mappers and find the one with the matching name
-	mappers, err := keycloakClient.ListGenericProtocolMappers(ctx, realmId, clientId, clientScopeId)
+	foundMapper, err := keycloakClient.GetGenericProtocolMapperByName(ctx, realmId, clientId, clientScopeId, name)
 	if err != nil {
 		return diag.FromErr(err)
-	}
-
-	var foundMapper *keycloak.GenericProtocolMapper
-	for _, mapper := range mappers {
-		if mapper.Name == name {
-			foundMapper = mapper
-			break
-		}
 	}
 
 	if foundMapper == nil {

--- a/provider/generic_protocol_mapper_helpers.go
+++ b/provider/generic_protocol_mapper_helpers.go
@@ -30,3 +30,33 @@ func genericProtocolMapperImport(_ context.Context, data *schema.ResourceData, _
 
 	return []*schema.ResourceData{data}, nil
 }
+
+// Temporary, duplicate helper function to support import of protocol mappers for which the schema
+// supports the import flag. One of these functions can be removed once all protocol mappers support
+// the import flag.
+func genericProtocolMapperImportWithImportFlag(_ context.Context, data *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(data.Id(), "/")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid import. supported import formats: {{realmId}}/client/{{clientId}}/{{protocolMapperId}}, {{realmId}}/client-scope/{{clientScopeId}}/{{protocolMapperId}}")
+	}
+
+	parentResourceType := parts[1]
+	parentResourceId := parts[2]
+
+	data.Set("realm_id", parts[0])
+	data.SetId(parts[3])
+
+	if parentResourceType == "client" {
+		data.Set("client_id", parentResourceId)
+	} else if parentResourceType == "client-scope" {
+		data.Set("client_scope_id", parentResourceId)
+	} else {
+		return nil, fmt.Errorf("the associated parent resource must be either a client or a client-scope")
+	}
+
+	// Schema defaults are not applied automatically during terraform import, so we set
+	// import = false explicitly to ensure ImportStateVerify passes.
+	data.Set("import", false)
+
+	return []*schema.ResourceData{data}, nil
+}

--- a/provider/generic_protocol_mapper_import_helpers_test.go
+++ b/provider/generic_protocol_mapper_import_helpers_test.go
@@ -1,0 +1,38 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func getGenericProtocolMapperIdForClient(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		id := rs.Primary.ID
+		realmId := rs.Primary.Attributes["realm_id"]
+		clientId := rs.Primary.Attributes["client_id"]
+
+		return fmt.Sprintf("%s/client/%s/%s", realmId, clientId, id), nil
+	}
+}
+
+func getGenericProtocolMapperIdForClientScope(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		id := rs.Primary.ID
+		realmId := rs.Primary.Attributes["realm_id"]
+		clientScopeId := rs.Primary.Attributes["client_scope_id"]
+
+		return fmt.Sprintf("%s/client-scope/%s/%s", realmId, clientScopeId, id), nil
+	}
+}

--- a/provider/generic_protocol_mapper_validation_test.go
+++ b/provider/generic_protocol_mapper_validation_test.go
@@ -400,7 +400,7 @@ func TestAccKeycloakOpenIdUserAttributeProtocolMapper_validateClientOrClientScop
 		Steps: []resource.TestStep{
 			{
 				Config:      testKeycloakOpenIdUserAttributeProtocolMapper_parentResourceValidation(mapperName),
-				ExpectError: regexp.MustCompile("validation error: one of ClientId or ClientScopeId must be set"),
+				ExpectError: regexp.MustCompile("one of `client_id,client_scope_id` must be specified"),
 			},
 		},
 	})
@@ -416,7 +416,7 @@ func TestAccKeycloakOpenIdUserPropertyProtocolMapper_validateClientOrClientScope
 		Steps: []resource.TestStep{
 			{
 				Config:      testKeycloakOpenIdUserPropertyProtocolMapper_parentResourceValidation(mapperName),
-				ExpectError: regexp.MustCompile("validation error: one of ClientId or ClientScopeId must be set"),
+				ExpectError: regexp.MustCompile("one of `client_id,client_scope_id` must be specified"),
 			},
 		},
 	})

--- a/provider/resource_keycloak_openid_full_name_protocol_mapper_test.go
+++ b/provider/resource_keycloak_openid_full_name_protocol_mapper_test.go
@@ -289,36 +289,6 @@ func getFullNameMapperUsingState(state *terraform.State, resourceName string) (*
 	return keycloakClient.GetOpenIdFullNameProtocolMapper(testCtx, realm, clientId, clientScopeId, id)
 }
 
-func getGenericProtocolMapperIdForClient(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("resource not found: %s", resourceName)
-		}
-
-		id := rs.Primary.ID
-		realmId := rs.Primary.Attributes["realm_id"]
-		clientId := rs.Primary.Attributes["client_id"]
-
-		return fmt.Sprintf("%s/client/%s/%s", realmId, clientId, id), nil
-	}
-}
-
-func getGenericProtocolMapperIdForClientScope(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
-		if !ok {
-			return "", fmt.Errorf("resource not found: %s", resourceName)
-		}
-
-		id := rs.Primary.ID
-		realmId := rs.Primary.Attributes["realm_id"]
-		clientScopeId := rs.Primary.Attributes["client_scope_id"]
-
-		return fmt.Sprintf("%s/client-scope/%s/%s", realmId, clientScopeId, id), nil
-	}
-}
-
 func testKeycloakOpenIdFullNameProtocolMapper_basic_client(clientId, mapperName string) string {
 	return fmt.Sprintf(`
 data "keycloak_realm" "realm" {

--- a/provider/resource_keycloak_openid_user_attribute_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_attribute_protocol_mapper.go
@@ -20,7 +20,7 @@ func resourceKeycloakOpenIdUserAttributeProtocolMapper() *schema.Resource {
 			// {{realmId}}/client/{{clientId}}/{{protocolMapperId}}
 			// or a client scope:
 			// {{realmId}}/client-scope/{{clientScopeId}}/{{protocolMapperId}}
-			StateContext: genericProtocolMapperImport,
+			StateContext: genericProtocolMapperImportWithImportFlag,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -35,18 +35,18 @@ func resourceKeycloakOpenIdUserAttributeProtocolMapper() *schema.Resource {
 				Description: "The realm id where the associated client or client scope exists.",
 			},
 			"client_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Description:   "The mapper's associated client. Cannot be used at the same time as client_scope_id.",
-				ConflictsWith: []string{"client_scope_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "The mapper's associated client. Cannot be used at the same time as client_scope_id.",
+				ExactlyOneOf: []string{"client_id", "client_scope_id"},
 			},
 			"client_scope_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Description:   "The mapper's associated client scope. Cannot be used at the same time as client_id.",
-				ConflictsWith: []string{"client_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "The mapper's associated client scope. Cannot be used at the same time as client_id.",
+				ExactlyOneOf: []string{"client_id", "client_scope_id"},
 			},
 			"add_to_id_token": {
 				Type:        schema.TypeBool,
@@ -99,6 +99,13 @@ func resourceKeycloakOpenIdUserAttributeProtocolMapper() *schema.Resource {
 				Default:     false,
 				Description: "Indicates if attribute values should be aggregated within the group attributes",
 			},
+			"import": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    false,
+				Description: "When true, the provider looks up an existing protocol mapper by name and updates it with the new configuration, overwriting any existing values. After the first apply, the resource behaves identically to one that was created normally, including deletion on terraform destroy.",
+			},
 		},
 	}
 }
@@ -147,17 +154,39 @@ func mapFromOpenIdUserAttributeMapperToData(mapper *keycloak.OpenIdUserAttribute
 
 func resourceKeycloakOpenIdUserAttributeProtocolMapperCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	keycloakClient := meta.(*keycloak.KeycloakClient)
+	importMode := data.Get("import").(bool)
 
 	openIdUserAttributeMapper := mapFromDataToOpenIdUserAttributeProtocolMapper(data)
 
-	err := keycloakClient.ValidateOpenIdUserAttributeProtocolMapper(ctx, openIdUserAttributeMapper)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	if importMode {
+		existingMapper, err := keycloakClient.GetOpenIdUserAttributeProtocolMapperByName(ctx, openIdUserAttributeMapper.RealmId, openIdUserAttributeMapper.ClientId, openIdUserAttributeMapper.ClientScopeId, openIdUserAttributeMapper.Name)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
-	err = keycloakClient.NewOpenIdUserAttributeProtocolMapper(ctx, openIdUserAttributeMapper)
-	if err != nil {
-		return diag.FromErr(err)
+		if existingMapper == nil {
+			return diag.Errorf("protocol mapper with name %q not found for import", openIdUserAttributeMapper.Name)
+		}
+
+		// We only preserve the ID of the existing mapper to ensure we update the correct resource
+		openIdUserAttributeMapper.Id = existingMapper.Id
+
+		err = keycloakClient.UpdateOpenIdUserAttributeProtocolMapper(ctx, openIdUserAttributeMapper)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		// Validation checks for existing protocol mappers with the same name, which is only
+		// relevant when creating a new protocol mapper, not when importing an existing one
+		err := keycloakClient.ValidateOpenIdUserAttributeProtocolMapper(ctx, openIdUserAttributeMapper)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		err = keycloakClient.NewOpenIdUserAttributeProtocolMapper(ctx, openIdUserAttributeMapper)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	mapFromOpenIdUserAttributeMapperToData(openIdUserAttributeMapper, data)

--- a/provider/resource_keycloak_openid_user_attribute_protocol_mapper_test.go
+++ b/provider/resource_keycloak_openid_user_attribute_protocol_mapper_test.go
@@ -88,6 +88,81 @@ func TestAccKeycloakOpenIdUserAttributeProtocolMapper_import(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakOpenIdUserAttributeProtocolMapper_importFlagClient_success(t *testing.T) {
+	t.Parallel()
+
+	mapperName := acctest.RandomWithPrefix("tf-acc")
+	initialAttributeName := acctest.RandomWithPrefix("tf-acc")
+	updatedAttributeName := acctest.RandomWithPrefix("tf-acc")
+	updatedClaimName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "keycloak_openid_user_attribute_protocol_mapper.imported_user_attribute_mapper"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createExternalOpenIdUserAttributeProtocolMapperForClient(t, "account", mapperName, initialAttributeName, "bar")
+		},
+		CheckDestroy: testAccKeycloakOpenIdUserAttributeProtocolMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenIdUserAttributeProtocolMapper_importFlagClient("account", mapperName, updatedAttributeName, updatedClaimName),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakOpenIdUserAttributeProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "user_attribute", updatedAttributeName),
+					resource.TestCheckResourceAttr(resourceName, "claim_name", updatedClaimName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOpenIdUserAttributeProtocolMapper_importFlagClientScope_success(t *testing.T) {
+	t.Parallel()
+
+	mapperName := acctest.RandomWithPrefix("tf-acc")
+	initialAttributeName := acctest.RandomWithPrefix("tf-acc")
+	updatedAttributeName := acctest.RandomWithPrefix("tf-acc")
+	updatedClaimName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "keycloak_openid_user_attribute_protocol_mapper.imported_user_attribute_mapper"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createExternalOpenIdUserAttributeProtocolMapperForClientScope(t, "profile", mapperName, initialAttributeName, "bar")
+		},
+		CheckDestroy: testAccKeycloakOpenIdUserAttributeProtocolMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenIdUserAttributeProtocolMapper_importFlagClientScope("profile", mapperName, updatedAttributeName, updatedClaimName),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakOpenIdUserAttributeProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "user_attribute", updatedAttributeName),
+					resource.TestCheckResourceAttr(resourceName, "claim_name", updatedClaimName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOpenIdUserAttributeProtocolMapper_importFlag_notFound(t *testing.T) {
+	t.Parallel()
+
+	mapperName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config:      testKeycloakOpenIdUserAttributeProtocolMapper_importFlagClient("account", mapperName, "foo", "bar"),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("protocol mapper with name %q not found for import", mapperName)),
+			},
+		},
+	})
+}
+
 func TestAccKeycloakOpenIdUserAttributeProtocolMapper_update(t *testing.T) {
 	t.Parallel()
 	clientId := acctest.RandomWithPrefix("tf-acc")
@@ -273,6 +348,74 @@ func getUserAttributeMapperUsingState(state *terraform.State, resourceName strin
 	return keycloakClient.GetOpenIdUserAttributeProtocolMapper(testCtx, realm, clientId, clientScopeId, id)
 }
 
+func createExternalOpenIdUserAttributeProtocolMapperForClient(t *testing.T, clientName, mapperName, userAttribute, claimName string) *keycloak.OpenIdUserAttributeProtocolMapper {
+	t.Helper()
+
+	client, err := keycloakClient.GetOpenidClientByClientId(testCtx, testAccRealm.Realm, clientName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mapper := &keycloak.OpenIdUserAttributeProtocolMapper{
+		Name:                    mapperName,
+		RealmId:                 testAccRealm.Realm,
+		ClientId:                client.Id,
+		AddToIdToken:            true,
+		AddToAccessToken:        true,
+		AddToUserInfo:           true,
+		AddToTokenIntrospection: true,
+		UserAttribute:           userAttribute,
+		ClaimName:               claimName,
+		ClaimValueType:          "String",
+	}
+
+	if err := keycloakClient.NewOpenIdUserAttributeProtocolMapper(testCtx, mapper); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = keycloakClient.DeleteOpenIdUserAttributeProtocolMapper(testCtx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId, mapper.Id)
+	})
+
+	return mapper
+}
+
+func createExternalOpenIdUserAttributeProtocolMapperForClientScope(t *testing.T, clientScopeName, mapperName, userAttribute, claimName string) *keycloak.OpenIdUserAttributeProtocolMapper {
+	t.Helper()
+
+	clientScopes, err := keycloakClient.ListOpenidClientScopesWithFilter(testCtx, testAccRealm.Realm, keycloak.IncludeOpenidClientScopesMatchingNames([]string{clientScopeName}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(clientScopes) != 1 {
+		t.Fatalf("expected client scope name %q to match 1 scope, matched %d", clientScopeName, len(clientScopes))
+	}
+
+	mapper := &keycloak.OpenIdUserAttributeProtocolMapper{
+		Name:                    mapperName,
+		RealmId:                 testAccRealm.Realm,
+		ClientScopeId:           clientScopes[0].Id,
+		AddToIdToken:            true,
+		AddToAccessToken:        true,
+		AddToUserInfo:           true,
+		AddToTokenIntrospection: true,
+		UserAttribute:           userAttribute,
+		ClaimName:               claimName,
+		ClaimValueType:          "String",
+	}
+
+	if err := keycloakClient.NewOpenIdUserAttributeProtocolMapper(testCtx, mapper); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = keycloakClient.DeleteOpenIdUserAttributeProtocolMapper(testCtx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId, mapper.Id)
+	})
+
+	return mapper
+}
+
 func testKeycloakOpenIdUserAttributeProtocolMapper_basic_client(clientId, mapperName string) string {
 	return fmt.Sprintf(`
 data "keycloak_realm" "realm" {
@@ -385,4 +528,48 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "user_attribute_mapper
 	claim_name        = "bar"
 	claim_value_type  = "%s"
 }`, testAccRealm.Realm, mapperName, claimValueType)
+}
+
+func testKeycloakOpenIdUserAttributeProtocolMapper_importFlagClient(clientName, mapperName, attributeName, claimName string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "imported_client" {
+	realm_id    = data.keycloak_realm.realm.id
+	client_id   = "%s"
+	access_type = "PUBLIC"
+	import      = true
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "imported_user_attribute_mapper" {
+	name           = "%s"
+	realm_id       = data.keycloak_realm.realm.id
+	client_id      = keycloak_openid_client.imported_client.id
+	import         = true
+	user_attribute = "%s"
+	claim_name     = "%s"
+}`, testAccRealm.Realm, clientName, mapperName, attributeName, claimName)
+}
+
+func testKeycloakOpenIdUserAttributeProtocolMapper_importFlagClientScope(clientScopeName, mapperName, attributeName, claimName string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+data "keycloak_openid_client_scope" "imported_client_scope" {
+	realm_id = data.keycloak_realm.realm.id
+	name     = "%s"
+}
+
+resource "keycloak_openid_user_attribute_protocol_mapper" "imported_user_attribute_mapper" {
+	name            = "%s"
+	realm_id        = data.keycloak_realm.realm.id
+	client_scope_id = data.keycloak_openid_client_scope.imported_client_scope.id
+	import          = true
+	user_attribute  = "%s"
+	claim_name      = "%s"
+}`, testAccRealm.Realm, clientScopeName, mapperName, attributeName, claimName)
 }

--- a/provider/resource_keycloak_openid_user_property_protocol_mapper.go
+++ b/provider/resource_keycloak_openid_user_property_protocol_mapper.go
@@ -20,7 +20,7 @@ func resourceKeycloakOpenIdUserPropertyProtocolMapper() *schema.Resource {
 			// {{realmId}}/client/{{clientId}}/{{protocolMapperId}}
 			// or a client scope:
 			// {{realmId}}/client-scope/{{clientScopeId}}/{{protocolMapperId}}
-			StateContext: genericProtocolMapperImport,
+			StateContext: genericProtocolMapperImportWithImportFlag,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -35,18 +35,18 @@ func resourceKeycloakOpenIdUserPropertyProtocolMapper() *schema.Resource {
 				Description: "The realm id where the associated client or client scope exists.",
 			},
 			"client_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Description:   "The mapper's associated client. Cannot be used at the same time as client_scope_id.",
-				ConflictsWith: []string{"client_scope_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "The mapper's associated client. Cannot be used at the same time as client_scope_id.",
+				ExactlyOneOf: []string{"client_id", "client_scope_id"},
 			},
 			"client_scope_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				Description:   "The mapper's associated client scope. Cannot be used at the same time as client_id.",
-				ConflictsWith: []string{"client_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "The mapper's associated client scope. Cannot be used at the same time as client_id.",
+				ExactlyOneOf: []string{"client_id", "client_scope_id"},
 			},
 			"add_to_id_token": {
 				Type:        schema.TypeBool,
@@ -80,6 +80,13 @@ func resourceKeycloakOpenIdUserPropertyProtocolMapper() *schema.Resource {
 				Description:  "Claim type used when serializing tokens.",
 				Default:      "String",
 				ValidateFunc: validation.StringInSlice([]string{"JSON", "String", "long", "int", "boolean"}, true),
+			},
+			"import": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    false,
+				Description: "When true, the provider looks up an existing protocol mapper by name and updates it with the new configuration, overwriting any existing values. After the first apply, the resource behaves identically to one that was created normally, including deletion on terraform destroy.",
 			},
 		},
 	}
@@ -123,17 +130,39 @@ func mapFromOpenIdUserPropertyMapperToData(mapper *keycloak.OpenIdUserPropertyPr
 
 func resourceKeycloakOpenIdUserPropertyProtocolMapperCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	keycloakClient := meta.(*keycloak.KeycloakClient)
+	importMode := data.Get("import").(bool)
 
 	openIdUserPropertyMapper := mapFromDataToOpenIdUserPropertyProtocolMapper(data)
 
-	err := openIdUserPropertyMapper.Validate(ctx, keycloakClient)
-	if err != nil {
-		return diag.FromErr(err)
-	}
+	if importMode {
+		existingMapper, err := keycloakClient.GetOpenIdUserPropertyProtocolMapperByName(ctx, openIdUserPropertyMapper.RealmId, openIdUserPropertyMapper.ClientId, openIdUserPropertyMapper.ClientScopeId, openIdUserPropertyMapper.Name)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
-	err = keycloakClient.NewOpenIdUserPropertyProtocolMapper(ctx, openIdUserPropertyMapper)
-	if err != nil {
-		return diag.FromErr(err)
+		if existingMapper == nil {
+			return diag.Errorf("protocol mapper with name %q not found for import", openIdUserPropertyMapper.Name)
+		}
+
+		// We only preserve the ID of the existing mapper to ensure we update the correct resource.
+		openIdUserPropertyMapper.Id = existingMapper.Id
+
+		err = keycloakClient.UpdateOpenIdUserPropertyProtocolMapper(ctx, openIdUserPropertyMapper)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		// Validation checks for existing protocol mappers with the same name, which is only
+		// relevant when creating a new protocol mapper, not when importing an existing one
+		err := openIdUserPropertyMapper.Validate(ctx, keycloakClient)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		err = keycloakClient.NewOpenIdUserPropertyProtocolMapper(ctx, openIdUserPropertyMapper)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	mapFromOpenIdUserPropertyMapperToData(openIdUserPropertyMapper, data)

--- a/provider/resource_keycloak_openid_user_property_protocol_mapper_test.go
+++ b/provider/resource_keycloak_openid_user_property_protocol_mapper_test.go
@@ -63,7 +63,7 @@ func TestAccKeycloakOpenIdUserPropertyProtocolMapper_import(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
 		PreCheck:                 func() { testAccPreCheck(t) },
-		CheckDestroy:             testAccKeycloakOpenIdFullNameProtocolMapperDestroy(),
+		CheckDestroy:             testAccKeycloakOpenIdUserPropertyProtocolMapperDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: testKeycloakOpenIdUserPropertyProtocolMapper_import(clientId, clientScopeId, mapperName),
@@ -83,6 +83,81 @@ func TestAccKeycloakOpenIdUserPropertyProtocolMapper_import(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: getGenericProtocolMapperIdForClientScope(clientScopeResourceName),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOpenIdUserPropertyProtocolMapper_importFlagClient_success(t *testing.T) {
+	t.Parallel()
+
+	mapperName := acctest.RandomWithPrefix("tf-acc")
+	initialPropertyName := acctest.RandomWithPrefix("tf-acc")
+	updatedPropertyName := acctest.RandomWithPrefix("tf-acc")
+	updatedClaimName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "keycloak_openid_user_property_protocol_mapper.imported_user_property_mapper"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createExternalOpenIdUserPropertyProtocolMapperForClient(t, "account", mapperName, initialPropertyName, "bar")
+		},
+		CheckDestroy: testAccKeycloakOpenIdUserPropertyProtocolMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenIdUserPropertyProtocolMapper_importFlagClient("account", mapperName, updatedPropertyName, updatedClaimName),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakOpenIdUserPropertyProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "user_property", updatedPropertyName),
+					resource.TestCheckResourceAttr(resourceName, "claim_name", updatedClaimName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOpenIdUserPropertyProtocolMapper_importFlagClientScope_success(t *testing.T) {
+	t.Parallel()
+
+	mapperName := acctest.RandomWithPrefix("tf-acc")
+	initialPropertyName := acctest.RandomWithPrefix("tf-acc")
+	updatedPropertyName := acctest.RandomWithPrefix("tf-acc")
+	updatedClaimName := acctest.RandomWithPrefix("tf-acc")
+	resourceName := "keycloak_openid_user_property_protocol_mapper.imported_user_property_mapper"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			createExternalOpenIdUserPropertyProtocolMapperForClientScope(t, "profile", mapperName, initialPropertyName, "bar")
+		},
+		CheckDestroy: testAccKeycloakOpenIdUserPropertyProtocolMapperDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOpenIdUserPropertyProtocolMapper_importFlagClientScope("profile", mapperName, updatedPropertyName, updatedClaimName),
+				Check: resource.ComposeTestCheckFunc(
+					testKeycloakOpenIdUserPropertyProtocolMapperExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "user_property", updatedPropertyName),
+					resource.TestCheckResourceAttr(resourceName, "claim_name", updatedClaimName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKeycloakOpenIdUserPropertyProtocolMapper_importFlag_notFound(t *testing.T) {
+	t.Parallel()
+
+	mapperName := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config:      testKeycloakOpenIdUserPropertyProtocolMapper_importFlagClient("account", mapperName, "foo", "bar"),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("protocol mapper with name %q not found for import", mapperName)),
 			},
 		},
 	})
@@ -298,6 +373,72 @@ func getUserPropertyMapperUsingState(state *terraform.State, resourceName string
 	return keycloakClient.GetOpenIdUserPropertyProtocolMapper(testCtx, realm, clientId, clientScopeId, id)
 }
 
+func createExternalOpenIdUserPropertyProtocolMapperForClient(t *testing.T, clientName, mapperName, userProperty, claimName string) *keycloak.OpenIdUserPropertyProtocolMapper {
+	t.Helper()
+
+	client, err := keycloakClient.GetOpenidClientByClientId(testCtx, testAccRealm.Realm, clientName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mapper := &keycloak.OpenIdUserPropertyProtocolMapper{
+		Name:             mapperName,
+		RealmId:          testAccRealm.Realm,
+		ClientId:         client.Id,
+		AddToIdToken:     true,
+		AddToAccessToken: true,
+		AddToUserInfo:    true,
+		UserProperty:     userProperty,
+		ClaimName:        claimName,
+		ClaimValueType:   "String",
+	}
+
+	if err := keycloakClient.NewOpenIdUserPropertyProtocolMapper(testCtx, mapper); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = keycloakClient.DeleteOpenIdUserPropertyProtocolMapper(testCtx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId, mapper.Id)
+	})
+
+	return mapper
+}
+
+func createExternalOpenIdUserPropertyProtocolMapperForClientScope(t *testing.T, clientScopeName, mapperName, userProperty, claimName string) *keycloak.OpenIdUserPropertyProtocolMapper {
+	t.Helper()
+
+	clientScopes, err := keycloakClient.ListOpenidClientScopesWithFilter(testCtx, testAccRealm.Realm, keycloak.IncludeOpenidClientScopesMatchingNames([]string{clientScopeName}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(clientScopes) != 1 {
+		t.Fatalf("expected client scope name %q to match 1 scope, matched %d", clientScopeName, len(clientScopes))
+	}
+
+	mapper := &keycloak.OpenIdUserPropertyProtocolMapper{
+		Name:             mapperName,
+		RealmId:          testAccRealm.Realm,
+		ClientScopeId:    clientScopes[0].Id,
+		AddToIdToken:     true,
+		AddToAccessToken: true,
+		AddToUserInfo:    true,
+		UserProperty:     userProperty,
+		ClaimName:        claimName,
+		ClaimValueType:   "String",
+	}
+
+	if err := keycloakClient.NewOpenIdUserPropertyProtocolMapper(testCtx, mapper); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		_ = keycloakClient.DeleteOpenIdUserPropertyProtocolMapper(testCtx, mapper.RealmId, mapper.ClientId, mapper.ClientScopeId, mapper.Id)
+	})
+
+	return mapper
+}
+
 func testKeycloakOpenIdUserPropertyProtocolMapper_basic_client(clientId, mapperName string) string {
 	return fmt.Sprintf(`
 data "keycloak_realm" "realm" {
@@ -410,4 +551,48 @@ resource "keycloak_openid_user_property_protocol_mapper" "user_property_mapper_v
 	claim_name       = "bar"
 	claim_value_type = "%s"
 }`, testAccRealm.Realm, mapperName, claimValueType)
+}
+
+func testKeycloakOpenIdUserPropertyProtocolMapper_importFlagClient(clientName, mapperName, propertyName, claimName string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_openid_client" "imported_client" {
+	realm_id    = data.keycloak_realm.realm.id
+	client_id   = "%s"
+	access_type = "PUBLIC"
+	import      = true
+}
+
+resource "keycloak_openid_user_property_protocol_mapper" "imported_user_property_mapper" {
+	name          = "%s"
+	realm_id      = data.keycloak_realm.realm.id
+	client_id     = keycloak_openid_client.imported_client.id
+	import        = true
+	user_property = "%s"
+	claim_name    = "%s"
+}`, testAccRealm.Realm, clientName, mapperName, propertyName, claimName)
+}
+
+func testKeycloakOpenIdUserPropertyProtocolMapper_importFlagClientScope(clientScopeName, mapperName, propertyName, claimName string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+data "keycloak_openid_client_scope" "imported_client_scope" {
+	realm_id = data.keycloak_realm.realm.id
+	name     = "%s"
+}
+
+resource "keycloak_openid_user_property_protocol_mapper" "imported_user_property_mapper" {
+	name            = "%s"
+	realm_id        = data.keycloak_realm.realm.id
+	client_scope_id = data.keycloak_openid_client_scope.imported_client_scope.id
+	import          = true
+	user_property   = "%s"
+	claim_name      = "%s"
+}`, testAccRealm.Realm, clientScopeName, mapperName, propertyName, claimName)
 }


### PR DESCRIPTION
**Summary**

Adds an import flag to `keycloak_openid_user_attribute_protocol_mapper` and `keycloak_openid_user_property_protocol_mapper` that allows Terraform to adopt a protocol mapper that already exists in Keycloak (e.g. one created by Keycloak automatically or managed outside of Terraform) without recreating it.

**Behavior**

When `import = true` is set on a resource:

 1. On terraform apply, the provider looks up the existing mapper by name under the given `realm_id` and `client_id`/`client_scope_id`.
 2. If found, it adopts the mapper's ID and updates it with the configured values (overwriting existing Keycloak settings with Terraform-managed ones, including schema defaults).
 3. If not found, the apply fails with a clear error.

After the first apply, import has no further effect. The resource is fully owned by Terraform, including deletion on terraform destroy.

**Changes**

 - New import attribute on both mapper resources
 - `ExactlyOneOf` validation replacing `ConflictsWith` for `client_id`/`client_scope_id` on both resources, moving the mutual-exclusion check to schema level
 - Refactored internal API: `listGenericProtocolMappers` renamed to `listProtocolMappers`; new shared `getProtocolMapperByName` used by all `GetXxxByName` and `Validate` functions, reducing redundant list-then-filter patterns
 - `GetGenericProtocolMapperByName` added; data source lookup simplified to use it directly
 - Validation functions updated to use `getProtocolMapperByName` (single targeted call instead of fetching all mappers) and fixed to correctly allow updates when the existing mapper ID matches (fixes a pre-existing bug in `OpenIdUserPropertyProtocolMapper.Validate` that blocked updates)
 - CLI terraform import correctly sets `import = false` in state via `genericProtocolMapperImport`
 - Tests for import-flag success, not-found error, and standard CLI import added