### PR TITLE
docs: add example for dynamic scope client

### DIFF
--- a/docs/resources/openid_client_scope.md
+++ b/docs/resources/openid_client_scope.md
@@ -27,6 +27,28 @@ resource "keycloak_openid_client_scope" "openid_client_scope" {
 }
 ```
 
+## Example Usage (Dynamic Scope)
+
+```hcl
+resource "keycloak_realm" "realm" {
+  realm   = "my-realm"
+  enabled = true
+}
+
+resource "keycloak_openid_client_scope" "dynamic_scope" {
+  realm_id                            = keycloak_realm.realm.id
+  name                                = "my-dynamic-scope"
+  description                         = "When requested, this scope will map a user's group memberships to a claim"
+  include_in_token_scope              = true
+  gui_order                           = 1
+
+  extra_config = {
+    "is.dynamic.scope"     = "true"
+    "dynamic.scope.regexp" = "my-dynamic-scope:*"
+  }
+}
+```
+
 ## Argument Reference
 
 - `realm_id` - (Required) The realm this client scope belongs to.


### PR DESCRIPTION
This change adds an example for how to create an OpenID client scope as a dynamic scope via `extra_config` using the `keycloak_openid_client_scope` resource.

The example is based on [this comment](https://github.com/keycloak/terraform-provider-keycloak/pull/1475#issuecomment-3929621713) in the PR that introduced `extra_config`. But I adapted the value of `dynamic.scope.regexp` based on the value I saw `attributes` of a client scope for which I toggled "Dynamic scope" in the GUI.

<img width="383" height="244" alt="image" src="https://github.com/user-attachments/assets/84632d35-c89c-4740-a2a3-2110b7d53746" />
