### PR TITLE
fix(custom_user_federation): keep all values of a multivalued config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * feat: support import for `keycloak_realm_default_client_scopes` and `keycloak_realm_optional_client_scopes` using the realm id
 
+BUG FIXES:
+
+* fix(custom_user_federation): keep all values of a multivalued `##` config setting instead of only the first ([#1398](https://github.com/keycloak/terraform-provider-keycloak/issues/1398))
+
 ## 5.8.0 (June 05, 2026)
 
 BREAKING CHANGES:

--- a/docs/resources/custom_user_federation.md
+++ b/docs/resources/custom_user_federation.md
@@ -27,7 +27,7 @@ resource "keycloak_custom_user_federation" "custom_user_federation" {
   config = {
     dummyString = "foobar"
     dummyBool   = true
-    multivalue = "value1##value2"
+    multivalue  = "value1##value2"
   }
 }
 ```
@@ -43,7 +43,7 @@ resource "keycloak_custom_user_federation" "custom_user_federation" {
 - `parent_id` - (Optional) Must be set to the realms' `internal_id`  when it differs from the realm. This can happen when existing resources are imported into the state.
 - `full_sync_period` - (Optional) How frequently Keycloak should sync all users, in seconds. Omit this property to disable periodic full sync.
 - `changed_sync_period` - (Optional) How frequently Keycloak should sync changed users, in seconds. Omit this property to disable periodic changed users sync.
-- `config` - (Optional) The provider configuration handed over to your custom user federation provider. In order to add multivalued settings, use `##` to separate the values.
+- `config` - (Optional) The provider configuration handed over to your custom user federation provider. To give a setting more than one value, join the values with `##`; each value is stored separately in Keycloak.
 
 ## Import
 

--- a/keycloak/custom_user_federation.go
+++ b/keycloak/custom_user_federation.go
@@ -33,7 +33,7 @@ func convertFromCustomUserFederationToComponent(custom *CustomUserFederation) *c
 
 	if custom.Config != nil {
 		for k, j := range custom.Config {
-			componentConfig[k] = append(componentConfig[k], j[0])
+			componentConfig[k] = j
 		}
 	}
 	componentConfig["cachePolicy"] = append(componentConfig["cachePolicy"], custom.CachePolicy)
@@ -83,9 +83,9 @@ func convertFromComponentToCustomUserFederation(component *component, realmName 
 		"changedSyncPeriod": true,
 	}
 	config := make(map[string][]string)
-	for k := range component.Config {
+	for k, v := range component.Config {
 		if found := configsToIgnore[k]; !found {
-			config[k] = append(config[k], component.getConfig(k))
+			config[k] = v
 		}
 	}
 

--- a/keycloak/custom_user_federation_test.go
+++ b/keycloak/custom_user_federation_test.go
@@ -1,0 +1,32 @@
+package keycloak
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConvertCustomUserFederationPreservesMultivaluedConfig(t *testing.T) {
+	values := []string{"a=1", "b=2", "c=3"}
+
+	custom := &CustomUserFederation{
+		Id:      "id",
+		Name:    "name",
+		RealmId: "realm",
+		Config: map[string][]string{
+			"user-extension-mappings": values,
+		},
+	}
+
+	component := convertFromCustomUserFederationToComponent(custom)
+	if got := component.Config["user-extension-mappings"]; !reflect.DeepEqual(got, values) {
+		t.Fatalf("write dropped config values: expected %v, got %v", values, got)
+	}
+
+	roundTripped, err := convertFromComponentToCustomUserFederation(component, "realm")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := roundTripped.Config["user-extension-mappings"]; !reflect.DeepEqual(got, values) {
+		t.Fatalf("read dropped config values: expected %v, got %v", values, got)
+	}
+}


### PR DESCRIPTION
config values are split on `##` into a `[]string`, but only the first element was written to Keycloak (`j[0]`) and only the first was read back (in `getConfig`). Settings with more than one `##`-separated value lost everything after the first, and because the read side dropped them too the plan never settled.

Write and read the full slice instead.

#761 added the `##` split/join to `getCustomUserFederationFromData`/`setCustomUserFederationData`, but the two conversions in `keycloak/custom_user_federation.go` were left as-is, so the slice was re-collapsed to its first element crossing into and out of the component struct. This patches those two remaining spots.

Fixes #1398