### PR TITLE
feat(provider): add config map to keycloak_generic_client_authorization_policy

### DIFF
--- a/docs/resources/generic_client_authorization_policy.md
+++ b/docs/resources/generic_client_authorization_policy.md
@@ -69,6 +69,20 @@ resource "keycloak_generic_client_authorization_policy" "deployed_js" {
   logic              = "POSITIVE"
   description        = "Authorization policy backed by a deployed JavaScript script"
 }
+
+# A custom Java SPI policy provider that reads its own settings from config.
+resource "keycloak_generic_client_authorization_policy" "custom_with_config" {
+  resource_server_id = keycloak_openid_client.test.resource_server_id
+  realm_id           = keycloak_realm.realm.id
+  name               = "my-configurable-policy"
+  type               = "my-custom-policy-provider"
+  decision_strategy  = "UNANIMOUS"
+  logic              = "POSITIVE"
+
+  config = {
+    some_setting = "some_value"
+  }
+}
 ```
 
 ## Argument Reference
@@ -85,6 +99,10 @@ The following arguments are supported:
 - `decision_strategy` - (Required) The decision strategy, can be one of `UNANIMOUS`, `AFFIRMATIVE`, or `CONSENSUS`.
 - `logic` - (Optional) The logic, can be one of `POSITIVE` or `NEGATIVE`. Defaults to `POSITIVE`.
 - `description` - (Optional) A description for the authorization policy.
+- `config` - (Optional) A map of provider-specific settings, passed through as-is to the policy's
+  `config` object. This is how a custom Java SPI provider that reads its own settings (connection
+  details, thresholds, anything the provider defines) receives them; Keycloak's generic
+  `PolicyRepresentation` carries these as a flat string-to-string map.
 
 ## Attributes Reference
 

--- a/docs/resources/generic_client_authorization_policy.md
+++ b/docs/resources/generic_client_authorization_policy.md
@@ -102,7 +102,8 @@ The following arguments are supported:
 - `config` - (Optional) A map of provider-specific settings, passed through as-is to the policy's
   `config` object. This is how a custom Java SPI provider that reads its own settings (connection
   details, thresholds, anything the provider defines) receives them; Keycloak's generic
-  `PolicyRepresentation` carries these as a flat string-to-string map.
+  `PolicyRepresentation` carries these as a flat string-to-string map, so values must be strings
+  and nested structures are not supported.
 
 ## Attributes Reference
 

--- a/keycloak/generic_client_authorization_policy.go
+++ b/keycloak/generic_client_authorization_policy.go
@@ -7,14 +7,15 @@ import (
 )
 
 type GenericClientAuthorizationPolicy struct {
-	Id               string `json:"id,omitempty"`
-	RealmId          string `json:"-"`
-	ResourceServerId string `json:"-"`
-	Name             string `json:"name"`
-	DecisionStrategy string `json:"decisionStrategy"`
-	Logic            string `json:"logic"`
-	Type             string `json:"type"`
-	Description      string `json:"description"`
+	Id               string            `json:"id,omitempty"`
+	RealmId          string            `json:"-"`
+	ResourceServerId string            `json:"-"`
+	Name             string            `json:"name"`
+	DecisionStrategy string            `json:"decisionStrategy"`
+	Logic            string            `json:"logic"`
+	Type             string            `json:"type"`
+	Description      string            `json:"description"`
+	Config           map[string]string `json:"config"`
 }
 
 func (keycloakClient *KeycloakClient) NewGenericClientAuthorizationPolicy(ctx context.Context, policy *GenericClientAuthorizationPolicy) error {

--- a/provider/resource_keycloak_generic_client_authorization_policy.go
+++ b/provider/resource_keycloak_generic_client_authorization_policy.go
@@ -51,11 +51,20 @@ func resourceKeycloakGenericClientAuthorizationPolicy() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"config": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
 		},
 	}
 }
 
 func getGenericClientAuthorizationPolicyFromData(data *schema.ResourceData) *keycloak.GenericClientAuthorizationPolicy {
+	config := make(map[string]string)
+	for k, v := range data.Get("config").(map[string]interface{}) {
+		config[k] = v.(string)
+	}
+
 	return &keycloak.GenericClientAuthorizationPolicy{
 		Id:               data.Id(),
 		ResourceServerId: data.Get("resource_server_id").(string),
@@ -65,6 +74,7 @@ func getGenericClientAuthorizationPolicyFromData(data *schema.ResourceData) *key
 		Name:             data.Get("name").(string),
 		Type:             data.Get("type").(string),
 		Description:      data.Get("description").(string),
+		Config:           config,
 	}
 }
 
@@ -78,6 +88,7 @@ func setGenericClientAuthorizationPolicyData(data *schema.ResourceData, policy *
 	data.Set("decision_strategy", policy.DecisionStrategy)
 	data.Set("logic", policy.Logic)
 	data.Set("description", policy.Description)
+	data.Set("config", policy.Config)
 }
 
 func resourceKeycloakGenericClientAuthorizationPolicyCreate(ctx context.Context, data *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/provider/resource_keycloak_generic_client_authorization_policy_test.go
+++ b/provider/resource_keycloak_generic_client_authorization_policy_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -21,20 +22,56 @@ func TestAccKeycloakGenericClientAuthorizationPolicy(t *testing.T) {
 	// the provider id returned by its PolicyProviderFactory.getId().
 	policyType := "script-always-granting-policy.js"
 
+	resourceName := "keycloak_generic_client_authorization_policy.test"
+
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
 		PreCheck:                 func() { testAccPreCheck(t) },
 		CheckDestroy:             testResourceKeycloakGenericClientAuthorizationPolicyDestroy(),
 		Steps: []resource.TestStep{
 			{
-				Config: testResourceKeycloakGenericClientAuthorizationPolicy_basic(clientId, policyName, policyType),
-				Check:  testResourceKeycloakGenericClientAuthorizationPolicyExists("keycloak_generic_client_authorization_policy.test"),
+				// The deployed JS policy in this test ignores config; it's set here purely
+				// to verify the attribute round-trips through create/read/update/import.
+				Config: testResourceKeycloakGenericClientAuthorizationPolicy_config(clientId, policyName, policyType, `{
+					foo = "bar"
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testResourceKeycloakGenericClientAuthorizationPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "config.foo", "bar"),
+					testResourceKeycloakGenericClientAuthorizationPolicyHasConfig(resourceName, map[string]string{"foo": "bar"}),
+				),
 			},
 			{
-				ResourceName:      "keycloak_generic_client_authorization_policy.test",
+				// Update: change a value and add a key. Proves Update sends the new config,
+				// not just Create.
+				Config: testResourceKeycloakGenericClientAuthorizationPolicy_config(clientId, policyName, policyType, `{
+					foo   = "baz"
+					other = "value"
+				}`),
+				Check: resource.ComposeTestCheckFunc(
+					testResourceKeycloakGenericClientAuthorizationPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "config.foo", "baz"),
+					resource.TestCheckResourceAttr(resourceName, "config.other", "value"),
+					testResourceKeycloakGenericClientAuthorizationPolicyHasConfig(resourceName, map[string]string{"foo": "baz", "other": "value"}),
+				),
+			},
+			{
+				// Clear config entirely. Regression check for a real bug caught in review:
+				// `omitempty` on the Go struct's Config field would drop the "config" key
+				// from the update payload for an empty map, leaving the previous values
+				// stuck on the server while Terraform reports a clean apply.
+				Config: testResourceKeycloakGenericClientAuthorizationPolicy_config(clientId, policyName, policyType, `{}`),
+				Check: resource.ComposeTestCheckFunc(
+					testResourceKeycloakGenericClientAuthorizationPolicyExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "config.%", "0"),
+					testResourceKeycloakGenericClientAuthorizationPolicyHasConfig(resourceName, map[string]string{}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateIdFunc: getResourceKeycloakGenericClientAuthorizationPolicyImportId("keycloak_generic_client_authorization_policy.test"),
+				ImportStateIdFunc: getResourceKeycloakGenericClientAuthorizationPolicyImportId(resourceName),
 			},
 		},
 	})
@@ -102,7 +139,38 @@ func testResourceKeycloakGenericClientAuthorizationPolicyExists(resourceName str
 	}
 }
 
-func testResourceKeycloakGenericClientAuthorizationPolicy_basic(clientId, policyName, policyType string) string {
+// testResourceKeycloakGenericClientAuthorizationPolicyHasConfig fetches the policy directly
+// from the Keycloak Admin API (independent of Terraform's own Read path) and asserts its
+// config matches expected. ImportStateVerify alone compares two reads that both go through
+// the same Read function, so it can't catch a case where Terraform's in-memory state is
+// correct but the value never actually reached (or was cleared on) the server.
+func testResourceKeycloakGenericClientAuthorizationPolicyHasConfig(resourceName string, expected map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		policy, err := getResourceKeycloakGenericClientAuthorizationPolicyFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		// A nil map (no config key returned by the server) and an empty map both mean
+		// "no config", normalize before comparing so the empty-config case isn't a
+		// false failure.
+		actual := policy.Config
+		if len(actual) == 0 {
+			actual = map[string]string{}
+		}
+		if len(expected) == 0 {
+			expected = map[string]string{}
+		}
+
+		if !reflect.DeepEqual(actual, expected) {
+			return fmt.Errorf("expected policy config to be %v, got %v", expected, actual)
+		}
+
+		return nil
+	}
+}
+
+func testResourceKeycloakGenericClientAuthorizationPolicy_config(clientId, policyName, policyType, configHcl string) string {
 	return fmt.Sprintf(`
 	data "keycloak_realm" "realm" {
 		realm = "%s"
@@ -125,6 +193,7 @@ func testResourceKeycloakGenericClientAuthorizationPolicy_basic(clientId, policy
 		type               = "%s"
 		decision_strategy  = "UNANIMOUS"
 		logic              = "POSITIVE"
+		config             = %s
 	}
-	`, testAccRealm.Realm, clientId, policyName, policyType)
+	`, testAccRealm.Realm, clientId, policyName, policyType, configHcl)
 }


### PR DESCRIPTION
`keycloak_generic_client_authorization_policy` can reference a custom Java SPI policy provider by type, but had no way to manage that provider's settings. Only external tooling could set the policy's config, matching Keycloak server's own PolicyRepresentation.config field.

This adds a config attribute (optional map) to the resource, following the precedent keycloak_custom_user_federation already set for the same need (#133).

Tested locally against a real Keycloak 26.7.0 instance (via `make local`), not just the unit-level `vet`/`fmtcheck`/`build` checks. Extended the acceptance test to cover create, update, and clearing of config, each step verified independently against the Admin API rather than only through Terraform's own state.

Fixes: keycloak/terraform-provider-keycloak#1675
