### PR TITLE
fix: Add allow_utf8 field to Keycloak realm data source

### DIFF
--- a/provider/data_source_keycloak_realm.go
+++ b/provider/data_source_keycloak_realm.go
@@ -230,6 +230,10 @@ func dataSourceKeycloakRealm() *schema.Resource {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
+						"allow_utf8": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
 						"auth": {
 							Type:     schema.TypeList,
 							Computed: true,


### PR DESCRIPTION
allow_utf8 is present in realm resource schema, but absent in the data source schema, which leads to using smtp_server from a realm data source to fail as deserialization does not find allow_utf8 attribute. This PR adds the missing attriubte