### PR TITLE
feat: add organization_id support to keycloak_group_roles

### DIFF
--- a/docs/resources/group_roles.md
+++ b/docs/resources/group_roles.md
@@ -118,16 +118,35 @@ resource "keycloak_group_roles" "group_role_association2" {
 }
 
 ```
+
+## Example Usage (organization group roles)
+
+Organization groups can be managed by setting `organization_id`. This requires Keycloak 26.6.0 or later.
+
+```hcl
+resource "keycloak_group_roles" "org_group_roles" {
+  realm_id        = keycloak_realm.realm.id
+  group_id        = data.keycloak_group.org_group.id
+  organization_id = keycloak_organization.my_org.id
+  exhaustive      = false
+
+  role_ids = [
+    keycloak_role.client_role.id,
+  ]
+}
+```
+
 ## Argument Reference
 
 - `realm_id` - (Required) The realm this group exists in.
 - `group_id` - (Required) The ID of the group this resource should manage roles for.
+- `organization_id` - (Optional) The ID of the organization this group belongs to. When provided, the group is managed via the Organization API. Required for Keycloak 26.6.0+ organization groups.
 - `role_ids` - (Required) A list of role IDs to map to the group.
 - `exhaustive` - (Optional) Indicates if the list of roles is exhaustive. In this case, roles that are manually added to the group will be removed. Defaults to `true`.
 
 ## Import
 
-This resource can be imported using the format `{{realm_id}}/{{group_id}}`, where `group_id` is the unique ID that Keycloak
+This resource can be imported using the format `{{realm_id}}/{{group_id}}` or `{{realm_id}}/{{organization_id}}/{{group_id}}`, where `group_id` is the unique ID that Keycloak
 assigns to the group upon creation. This value can be found in the URI when editing this group in the GUI, and is typically
 a GUID.
 
@@ -135,4 +154,10 @@ Example:
 
 ```bash
 $ terraform import keycloak_group_roles.group_roles my-realm/18cc6b87-2ce7-4e59-bdc8-b9d49ec98a94
+```
+
+For organization groups:
+
+```bash
+$ terraform import keycloak_group_roles.org_group_roles my-realm/12f6303b-676c-4376-99e2-bbad747960dc/18cc6b87-2ce7-4e59-bdc8-b9d49ec98a94
 ```

--- a/keycloak/group_role_mappings.go
+++ b/keycloak/group_role_mappings.go
@@ -5,9 +5,20 @@ import (
 	"fmt"
 )
 
-func (keycloakClient *KeycloakClient) GetGroupRoleMappings(ctx context.Context, realmId string, userId string) (*RoleMapping, error) {
+func groupRoleMappingsUrl(realmId, organizationId, groupId string) string {
+	if organizationId != "" {
+		return fmt.Sprintf("/realms/%s/organizations/%s/groups/%s/role-mappings", realmId, organizationId, groupId)
+	}
+	return fmt.Sprintf("/realms/%s/groups/%s/role-mappings", realmId, groupId)
+}
+
+func (keycloakClient *KeycloakClient) GetGroupRoleMappings(ctx context.Context, realmId string, groupId string) (*RoleMapping, error) {
+	return keycloakClient.GetOrganizationGroupRoleMappings(ctx, realmId, "", groupId)
+}
+
+func (keycloakClient *KeycloakClient) GetOrganizationGroupRoleMappings(ctx context.Context, realmId, organizationId, groupId string) (*RoleMapping, error) {
 	var roleMapping *RoleMapping
-	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/groups/%s/role-mappings", realmId, userId), &roleMapping, nil)
+	err := keycloakClient.get(ctx, groupRoleMappingsUrl(realmId, organizationId, groupId), &roleMapping, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -16,25 +27,37 @@ func (keycloakClient *KeycloakClient) GetGroupRoleMappings(ctx context.Context, 
 }
 
 func (keycloakClient *KeycloakClient) AddRealmRolesToGroup(ctx context.Context, realmId, groupId string, roles []*Role) error {
-	_, _, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/groups/%s/role-mappings/realm", realmId, groupId), roles)
+	return keycloakClient.AddRealmRolesToOrganizationGroup(ctx, realmId, "", groupId, roles)
+}
 
+func (keycloakClient *KeycloakClient) AddRealmRolesToOrganizationGroup(ctx context.Context, realmId, organizationId, groupId string, roles []*Role) error {
+	_, _, err := keycloakClient.post(ctx, fmt.Sprintf("%s/realm", groupRoleMappingsUrl(realmId, organizationId, groupId)), roles)
 	return err
 }
 
 func (keycloakClient *KeycloakClient) AddClientRolesToGroup(ctx context.Context, realmId, groupId, clientId string, roles []*Role) error {
-	_, _, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/groups/%s/role-mappings/clients/%s", realmId, groupId, clientId), roles)
+	return keycloakClient.AddClientRolesToOrganizationGroup(ctx, realmId, "", groupId, clientId, roles)
+}
 
+func (keycloakClient *KeycloakClient) AddClientRolesToOrganizationGroup(ctx context.Context, realmId, organizationId, groupId, clientId string, roles []*Role) error {
+	_, _, err := keycloakClient.post(ctx, fmt.Sprintf("%s/clients/%s", groupRoleMappingsUrl(realmId, organizationId, groupId), clientId), roles)
 	return err
 }
 
 func (keycloakClient *KeycloakClient) RemoveRealmRolesFromGroup(ctx context.Context, realmId, groupId string, roles []*Role) error {
-	err := keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/groups/%s/role-mappings/realm", realmId, groupId), roles)
+	return keycloakClient.RemoveRealmRolesFromOrganizationGroup(ctx, realmId, "", groupId, roles)
+}
 
+func (keycloakClient *KeycloakClient) RemoveRealmRolesFromOrganizationGroup(ctx context.Context, realmId, organizationId, groupId string, roles []*Role) error {
+	err := keycloakClient.delete(ctx, fmt.Sprintf("%s/realm", groupRoleMappingsUrl(realmId, organizationId, groupId)), roles)
 	return err
 }
 
 func (keycloakClient *KeycloakClient) RemoveClientRolesFromGroup(ctx context.Context, realmId, groupId, clientId string, roles []*Role) error {
-	err := keycloakClient.delete(ctx, fmt.Sprintf("/realms/%s/groups/%s/role-mappings/clients/%s", realmId, groupId, clientId), roles)
+	return keycloakClient.RemoveClientRolesFromOrganizationGroup(ctx, realmId, "", groupId, clientId, roles)
+}
 
+func (keycloakClient *KeycloakClient) RemoveClientRolesFromOrganizationGroup(ctx context.Context, realmId, organizationId, groupId, clientId string, roles []*Role) error {
+	err := keycloakClient.delete(ctx, fmt.Sprintf("%s/clients/%s", groupRoleMappingsUrl(realmId, organizationId, groupId), clientId), roles)
 	return err
 }

--- a/provider/resource_keycloak_group_roles.go
+++ b/provider/resource_keycloak_group_roles.go
@@ -32,6 +32,12 @@ func resourceKeycloakGroupRoles() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"organization_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "When provided, the group is treated as an organization group and managed via the Organization API. Required for Keycloak 26.6.0+ organization groups.",
+			},
 			"role_ids": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -53,7 +59,7 @@ func groupRolesId(realmId, groupId string) string {
 
 func addRolesToGroup(ctx context.Context, keycloakClient *keycloak.KeycloakClient, clientRolesToAdd map[string][]*keycloak.Role, realmRolesToAdd []*keycloak.Role, group *keycloak.Group) error {
 	if len(realmRolesToAdd) != 0 {
-		err := keycloakClient.AddRealmRolesToGroup(ctx, group.RealmId, group.Id, realmRolesToAdd)
+		err := keycloakClient.AddRealmRolesToOrganizationGroup(ctx, group.RealmId, group.OrganizationId, group.Id, realmRolesToAdd)
 		if err != nil {
 			return err
 		}
@@ -61,7 +67,7 @@ func addRolesToGroup(ctx context.Context, keycloakClient *keycloak.KeycloakClien
 
 	for k, roles := range clientRolesToAdd {
 		if len(roles) != 0 {
-			err := keycloakClient.AddClientRolesToGroup(ctx, group.RealmId, group.Id, k, roles)
+			err := keycloakClient.AddClientRolesToOrganizationGroup(ctx, group.RealmId, group.OrganizationId, group.Id, k, roles)
 			if err != nil {
 				return err
 			}
@@ -73,7 +79,7 @@ func addRolesToGroup(ctx context.Context, keycloakClient *keycloak.KeycloakClien
 
 func removeRolesFromGroup(ctx context.Context, keycloakClient *keycloak.KeycloakClient, clientRolesToRemove map[string][]*keycloak.Role, realmRolesToRemove []*keycloak.Role, group *keycloak.Group) error {
 	if len(realmRolesToRemove) != 0 {
-		err := keycloakClient.RemoveRealmRolesFromGroup(ctx, group.RealmId, group.Id, realmRolesToRemove)
+		err := keycloakClient.RemoveRealmRolesFromOrganizationGroup(ctx, group.RealmId, group.OrganizationId, group.Id, realmRolesToRemove)
 		if err != nil {
 			return err
 		}
@@ -81,7 +87,7 @@ func removeRolesFromGroup(ctx context.Context, keycloakClient *keycloak.Keycloak
 
 	for k, roles := range clientRolesToRemove {
 		if len(roles) != 0 {
-			err := keycloakClient.RemoveClientRolesFromGroup(ctx, group.RealmId, group.Id, k, roles)
+			err := keycloakClient.RemoveClientRolesFromOrganizationGroup(ctx, group.RealmId, group.OrganizationId, group.Id, k, roles)
 			if err != nil {
 				return err
 			}
@@ -98,8 +104,9 @@ func resourceKeycloakGroupRolesReconcile(ctx context.Context, data *schema.Resou
 	groupId := data.Get("group_id").(string)
 	roleIds := interfaceSliceToStringSlice(data.Get("role_ids").(*schema.Set).List())
 	exhaustive := data.Get("exhaustive").(bool)
+	organizationId := data.Get("organization_id").(string)
 
-	group, err := keycloakClient.GetGroup(ctx, realmId, groupId)
+	group, err := keycloakClient.GetOrganizationGroup(ctx, realmId, organizationId, groupId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -126,7 +133,10 @@ func resourceKeycloakGroupRolesReconcile(ctx context.Context, data *schema.Resou
 	}
 
 	// get the list of currently assigned roles. Due to default realm and client roles
-	roleMappings, err := keycloakClient.GetGroupRoleMappings(ctx, realmId, groupId)
+	roleMappings, err := keycloakClient.GetOrganizationGroupRoleMappings(ctx, realmId, organizationId, groupId)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	// sort into roles we need to add and roles we need to remove
 	updates := calculateRoleMappingUpdates(tfRoles, intoRoleMapping(roleMappings))
@@ -157,13 +167,14 @@ func resourceKeycloakGroupRolesRead(ctx context.Context, data *schema.ResourceDa
 	groupId := data.Get("group_id").(string)
 	sortedRoleIds := interfaceSliceToStringSlice(data.Get("role_ids").(*schema.Set).List())
 	exhaustive := data.Get("exhaustive").(bool)
+	organizationId := data.Get("organization_id").(string)
 
 	// check if group exists, remove from state if not found
-	if _, err := keycloakClient.GetGroup(ctx, realmId, groupId); err != nil {
+	if _, err := keycloakClient.GetOrganizationGroup(ctx, realmId, organizationId, groupId); err != nil {
 		return handleNotFoundError(ctx, err, data)
 	}
 
-	roles, err := keycloakClient.GetGroupRoleMappings(ctx, realmId, groupId)
+	roles, err := keycloakClient.GetOrganizationGroupRoleMappings(ctx, realmId, organizationId, groupId)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -195,8 +206,9 @@ func resourceKeycloakGroupRolesDelete(ctx context.Context, data *schema.Resource
 
 	realmId := data.Get("realm_id").(string)
 	groupId := data.Get("group_id").(string)
+	organizationId := data.Get("organization_id").(string)
 
-	group, err := keycloakClient.GetGroup(ctx, realmId, groupId)
+	group, err := keycloakClient.GetOrganizationGroup(ctx, realmId, organizationId, groupId)
 	if err != nil {
 		return handleNotFoundError(ctx, err, data)
 	}
@@ -219,24 +231,33 @@ func resourceKeycloakGroupRolesImport(ctx context.Context, d *schema.ResourceDat
 	keycloakClient := meta.(*keycloak.KeycloakClient)
 
 	parts := strings.Split(d.Id(), "/")
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("Invalid import. Supported import format: {{realm}}/{{groupId}}.")
+	if len(parts) != 2 && len(parts) != 3 {
+		return nil, fmt.Errorf("Invalid import. Supported import formats: {{realm}}/{{groupId}} or {{realm}}/{{organizationId}}/{{groupId}}.")
 	}
 
 	realmId := parts[0]
-	groupId := parts[1]
+	var organizationId, groupId string
+	if len(parts) == 3 {
+		organizationId = parts[1]
+		groupId = parts[2]
+	} else {
+		groupId = parts[1]
+	}
 
-	if _, err := keycloakClient.GetGroup(ctx, realmId, groupId); err != nil {
+	if _, err := keycloakClient.GetOrganizationGroup(ctx, realmId, organizationId, groupId); err != nil {
 		return nil, err
 	}
 
-	_, err := keycloakClient.GetGroupRoleMappings(ctx, realmId, groupId)
+	_, err := keycloakClient.GetOrganizationGroupRoleMappings(ctx, realmId, organizationId, groupId)
 	if err != nil {
 		return nil, err
 	}
 
 	d.Set("realm_id", realmId)
 	d.Set("group_id", groupId)
+	if organizationId != "" {
+		d.Set("organization_id", organizationId)
+	}
 	d.Set("exhaustive", true)
 
 	diagnostics := resourceKeycloakGroupRolesRead(ctx, d, meta)


### PR DESCRIPTION
## Summary

Adds an optional `organization_id` attribute to the `keycloak_group_roles` resource. When set, all role mapping operations use the Keycloak Organization API path instead of the regular groups API.

## Problem

Keycloak 26.6.0+ introduced organization groups, which must be managed via the Organization API. Attempting to manage role mappings for organization groups through the regular groups API results in:

```
Cannot manage organization related group via non Organization API.
```

The `data.keycloak_group` data source already supports `organization_id` (added in #1607, v5.8.0), but `keycloak_group_roles` does not — making it impossible to assign roles to organization groups via Terraform.

## Changes

- **`keycloak/group_role_mappings.go`**: Added a `groupRoleMappingsUrl` helper that routes to the organization API when `organizationId` is set. Added Organization variants of all role mapping functions. Original functions delegate with an empty `organizationId` to preserve backward compatibility.
- **`provider/resource_keycloak_group_roles.go`**: Added `organization_id` schema attribute (optional, ForceNew). All CRUD functions now use `GetOrganizationGroup` and organization-aware role mapping functions. Import supports both `{{realm}}/{{groupId}}` and `{{realm}}/{{organizationId}}/{{groupId}}` formats.
- **`docs/resources/group_roles.md`**: Added organization group example, updated argument reference and import format.

## Example usage

```hcl
data "keycloak_group" "org_group" {
  realm_id        = keycloak_realm.realm.id
  organization_id = keycloak_organization.my_org.id
  name            = "my-org-group"
}

resource "keycloak_group_roles" "org_group_roles" {
  realm_id        = keycloak_realm.realm.id
  group_id        = data.keycloak_group.org_group.id
  organization_id = keycloak_organization.my_org.id
  exhaustive      = false

  role_ids = [
    keycloak_role.client_role.id,
  ]
}
```

## Notes

- Requires Keycloak 26.6.0 or later for organization group support
- Fully backward compatible — omitting `organization_id` uses the existing groups API
- Builds on the organization group support added in #1607