### PR TITLE
feat(group_admin_permissions): add manage-membership-of-members and impersonate-members scopes

### DIFF
--- a/docs/resources/group_admin_permissions.md
+++ b/docs/resources/group_admin_permissions.md
@@ -19,6 +19,8 @@ Available scopes:
 - `view-members` — view user details of the group's members
 - `manage-members` — manage the users that belong to this group
 - `manage-membership` — add or remove members from this group
+- `manage-membership-of-members` — change the group memberships of this group's members (requires Keycloak 26.6 or later)
+- `impersonate-members` — impersonate the users that belong to this group
 
 ## Example Usage
 
@@ -86,7 +88,7 @@ resource "keycloak_group_admin_permissions" "admins_view_all_groups" {
 - `description` - (Optional) Description of the permission.
 - `decision_strategy` - (Optional) Decision strategy. One of `UNANIMOUS`, `AFFIRMATIVE`, or `CONSENSUS`. Defaults to `UNANIMOUS`.
 - `group_ids` - (Optional) Set of group UUIDs (`keycloak_group.xxx.id`) this permission applies to. When omitted or empty, the permission applies to **all groups** in the realm.
-- `scopes` - (Required) Set of scopes this permission grants. Valid values: `view`, `manage`, `view-members`, `manage-members`, `manage-membership`.
+- `scopes` - (Required) Set of scopes this permission grants. Valid values: `view`, `manage`, `view-members`, `manage-members`, `manage-membership`, `manage-membership-of-members`, `impersonate-members`.
 - `policies` - (Optional) Set of policy IDs to attach to the permission.
 
 ## Attributes Reference

--- a/provider/resource_keycloak_group_admin_permissions.go
+++ b/provider/resource_keycloak_group_admin_permissions.go
@@ -16,6 +16,8 @@ var groupAdminPermissionScopes = []string{
 	"view-members",
 	"manage-members",
 	"manage-membership",
+	"manage-membership-of-members",
+	"impersonate-members",
 }
 
 func resourceKeycloakGroupAdminPermissions() *schema.Resource {

--- a/provider/resource_keycloak_group_admin_permissions_test.go
+++ b/provider/resource_keycloak_group_admin_permissions_test.go
@@ -27,10 +27,34 @@ func TestAccKeycloakGroupAdminPermissions_basic(t *testing.T) {
 				Check:  testAccCheckKeycloakGroupAdminPermissionsExists("keycloak_group_admin_permissions.test"),
 			},
 			{
+				Config: testKeycloakGroupAdminPermissions_basic("manage-membership"),
+				Check:  testAccCheckKeycloakGroupAdminPermissionsExists("keycloak_group_admin_permissions.test"),
+			},
+			{
+				Config: testKeycloakGroupAdminPermissions_basic("impersonate-members"),
+				Check:  testAccCheckKeycloakGroupAdminPermissionsExists("keycloak_group_admin_permissions.test"),
+			},
+			{
 				ResourceName:            "keycloak_group_admin_permissions.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"group_ids"},
+			},
+		},
+	})
+}
+
+func TestAccKeycloakGroupAdminPermissions_manageMembershipOfMembers(t *testing.T) {
+	skipIfVersionIsLessThan(testCtx, t, keycloakClient, keycloak.Version_26_6)
+	skipIfFGAPv2NotEnabled(testCtx, t, keycloakClient)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakGroupAdminPermissions_basic("manage-membership-of-members"),
+				Check:  testAccCheckKeycloakGroupAdminPermissionsExists("keycloak_group_admin_permissions.test"),
 			},
 		},
 	})


### PR DESCRIPTION
Add the two missing Groups resource type scopes to the FGAPv2 group admin permission resource, cover manage-membership and impersonate-members in the basic acceptance test, and gate manage-membership-of-members behind Keycloak 26.6 in a dedicated test.

Fixes #1685 