### PR TITLE
Support copying built-in authentication flows

### DIFF
--- a/docs/resources/authentication_flow.md
+++ b/docs/resources/authentication_flow.md
@@ -31,12 +31,46 @@ resource "keycloak_authentication_execution" "execution" {
 }
 ```
 
+### Copying a built-in flow, then restructuring it
+
+Built-in flows (such as `browser`, `direct grant`, `registration`, `first broker login`, `clients`, and `docker auth`) can have
+the `requirement` of their *existing* executions configured freely (that part already works against the built-in flow itself),
+but Keycloak rejects any attempt to restructure them - adding a new execution, removing one, or adding a subflow all fail with
+errors like `It is illegal to add execution to a built in flow`. Copying the flow with `copy_from` removes that restriction:
+the copy includes all of the source flow's executions and subflows, and - unlike the original - is not built-in, so executions
+and subflows can be added to or removed from it. The new flow can then be bound in place of the original via
+`keycloak_authentication_bindings`.
+
+```hcl
+resource "keycloak_authentication_flow" "custom_browser" {
+  realm_id  = keycloak_realm.realm.id
+  alias     = "my-custom-browser"
+  copy_from = "browser"
+}
+
+resource "keycloak_authentication_bindings" "bindings" {
+  realm_id     = keycloak_realm.realm.id
+  browser_flow = keycloak_authentication_flow.custom_browser.alias
+}
+
+# Adding a brand new top-level execution like this - e.g. offering WebAuthn/passkey login as
+# an alternative to username+password - fails with "It is illegal to add execution to a built
+# in flow" against "browser" itself, but succeeds on the copy.
+resource "keycloak_authentication_execution" "webauthn_passwordless" {
+  realm_id          = keycloak_realm.realm.id
+  parent_flow_alias = keycloak_authentication_flow.custom_browser.alias
+  authenticator     = "webauthn-authenticator-passwordless"
+  requirement       = "ALTERNATIVE"
+}
+```
+
 ## Argument Reference
 
 - `realm_id` - (Required) The realm that the authentication flow exists in.
 - `alias` - (Required) The alias for this authentication flow.
 - `description` - (Optional) A description for the authentication flow.
-- `provider_id` - (Optional) The type of authentication flow to create. Valid choices include `basic-flow` and `client-flow`. Defaults to `basic-flow`.
+- `provider_id` - (Optional) The type of authentication flow to create. Valid choices include `basic-flow` and `client-flow`. Defaults to `basic-flow`. Ignored when `copy_from` is set, since the copy inherits its type from the source flow.
+- `copy_from` - (Optional) The alias of an existing authentication flow (built-in or custom) to copy. All executions and subflows of the source flow are duplicated into this flow. Changing this attribute will force creation of a new resource.
 
 ## Import
 

--- a/keycloak/authentication_flow.go
+++ b/keycloak/authentication_flow.go
@@ -44,6 +44,22 @@ func (keycloakClient *KeycloakClient) NewAuthenticationFlow(ctx context.Context,
 	return nil
 }
 
+type authenticationFlowCopyRequest struct {
+	NewName string `json:"newName"`
+}
+
+// CopyAuthenticationFlow duplicates an existing flow (including all of its executions and
+// subflows) under a new alias. Unlike a built-in flow, the resulting copy is not builtIn and
+// can be freely modified.
+func (keycloakClient *KeycloakClient) CopyAuthenticationFlow(ctx context.Context, realmId, flowAlias, newName string) (string, error) {
+	_, location, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/authentication/flows/%s/copy", realmId, flowAlias), &authenticationFlowCopyRequest{NewName: newName})
+	if err != nil {
+		return "", err
+	}
+
+	return getIdFromLocationHeader(location), nil
+}
+
 func (keycloakClient *KeycloakClient) GetAuthenticationFlow(ctx context.Context, realmId, id string) (*AuthenticationFlow, error) {
 	var authenticationFlow AuthenticationFlow
 	err := keycloakClient.get(ctx, fmt.Sprintf("/realms/%s/authentication/flows/%s", realmId, id), &authenticationFlow, nil)

--- a/keycloak/authentication_flow.go
+++ b/keycloak/authentication_flow.go
@@ -51,13 +51,13 @@ type authenticationFlowCopyRequest struct {
 // CopyAuthenticationFlow duplicates an existing flow (including all of its executions and
 // subflows) under a new alias. Unlike a built-in flow, the resulting copy is not builtIn and
 // can be freely modified.
-func (keycloakClient *KeycloakClient) CopyAuthenticationFlow(ctx context.Context, realmId, flowAlias, newName string) (string, error) {
-	_, location, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/authentication/flows/%s/copy", realmId, flowAlias), &authenticationFlowCopyRequest{NewName: newName})
-	if err != nil {
-		return "", err
-	}
-
-	return getIdFromLocationHeader(location), nil
+//
+// The copy endpoint does not reliably return a Location header across Keycloak versions, so
+// callers must look up the resulting flow by its new alias (e.g. via GetAuthenticationFlowFromAlias)
+// rather than relying on a returned id.
+func (keycloakClient *KeycloakClient) CopyAuthenticationFlow(ctx context.Context, realmId, flowAlias, newName string) error {
+	_, _, err := keycloakClient.post(ctx, fmt.Sprintf("/realms/%s/authentication/flows/%s/copy", realmId, flowAlias), &authenticationFlowCopyRequest{NewName: newName})
+	return err
 }
 
 func (keycloakClient *KeycloakClient) GetAuthenticationFlow(ctx context.Context, realmId, id string) (*AuthenticationFlow, error) {

--- a/provider/resource_keycloak_authentication_flow.go
+++ b/provider/resource_keycloak_authentication_flow.go
@@ -32,10 +32,11 @@ func resourceKeycloakAuthenticationFlow() *schema.Resource {
 				Required: true,
 			},
 			"provider_id": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"basic-flow", "client-flow"}, false), //it seems toplevel can only one of these and not 'form-flow'
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ValidateFunc:  validation.StringInSlice([]string{"basic-flow", "client-flow"}, false), //it seems toplevel can only one of these and not 'form-flow'
+				ConflictsWith: []string{"copy_from"},
 			},
 			"description": {
 				Type:             schema.TypeString,
@@ -43,10 +44,11 @@ func resourceKeycloakAuthenticationFlow() *schema.Resource {
 				DiffSuppressFunc: suppressDiffWhenNotInConfig("description"),
 			},
 			"copy_from": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "The alias of an existing authentication flow (built-in or custom) to copy. All executions and subflows of the source flow are duplicated into this flow, which - unlike a built-in flow - can then be freely modified.",
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"provider_id"},
+				Description:   "The alias of an existing authentication flow (built-in or custom) to copy. All executions and subflows of the source flow are duplicated into this flow, which - unlike a built-in flow - can then be freely modified.",
 			},
 		},
 	}
@@ -92,7 +94,14 @@ func resourceKeycloakAuthenticationFlowCreate(ctx context.Context, data *schema.
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		authenticationFlow.Id = id
+
+		// The copy endpoint only accepts a new alias, inheriting everything else (description,
+		// provider_id, ...) from the source flow, so re-fetch the created flow instead of relying
+		// on the partially-populated struct built from config.
+		authenticationFlow, err = keycloakClient.GetAuthenticationFlow(ctx, authenticationFlow.RealmId, id)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	} else {
 		if _, ok := data.GetOkExists("provider_id"); !ok {
 			authenticationFlow.ProviderId = "basic-flow"

--- a/provider/resource_keycloak_authentication_flow.go
+++ b/provider/resource_keycloak_authentication_flow.go
@@ -33,14 +33,20 @@ func resourceKeycloakAuthenticationFlow() *schema.Resource {
 			},
 			"provider_id": {
 				Type:         schema.TypeString,
-				Default:      "basic-flow",
-				ValidateFunc: validation.StringInSlice([]string{"basic-flow", "client-flow"}, false), //it seems toplevel can only one of these and not 'form-flow'
 				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"basic-flow", "client-flow"}, false), //it seems toplevel can only one of these and not 'form-flow'
 			},
 			"description": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				DiffSuppressFunc: suppressDiffWhenNotInConfig("description"),
+			},
+			"copy_from": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The alias of an existing authentication flow (built-in or custom) to copy. All executions and subflows of the source flow are duplicated into this flow, which - unlike a built-in flow - can then be freely modified.",
 			},
 		},
 	}
@@ -81,9 +87,21 @@ func resourceKeycloakAuthenticationFlowCreate(ctx context.Context, data *schema.
 
 	authenticationFlow := mapFromDataToAuthenticationFlow(data)
 
-	err := keycloakClient.NewAuthenticationFlow(ctx, authenticationFlow)
-	if err != nil {
-		return diag.FromErr(err)
+	if copyFrom, ok := data.GetOk("copy_from"); ok {
+		id, err := keycloakClient.CopyAuthenticationFlow(ctx, authenticationFlow.RealmId, copyFrom.(string), authenticationFlow.Alias)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		authenticationFlow.Id = id
+	} else {
+		if _, ok := data.GetOkExists("provider_id"); !ok {
+			authenticationFlow.ProviderId = "basic-flow"
+		}
+
+		err := keycloakClient.NewAuthenticationFlow(ctx, authenticationFlow)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	mapFromAuthenticationFlowToData(data, authenticationFlow)

--- a/provider/resource_keycloak_authentication_flow.go
+++ b/provider/resource_keycloak_authentication_flow.go
@@ -90,15 +90,15 @@ func resourceKeycloakAuthenticationFlowCreate(ctx context.Context, data *schema.
 	authenticationFlow := mapFromDataToAuthenticationFlow(data)
 
 	if copyFrom, ok := data.GetOk("copy_from"); ok {
-		id, err := keycloakClient.CopyAuthenticationFlow(ctx, authenticationFlow.RealmId, copyFrom.(string), authenticationFlow.Alias)
+		err := keycloakClient.CopyAuthenticationFlow(ctx, authenticationFlow.RealmId, copyFrom.(string), authenticationFlow.Alias)
 		if err != nil {
 			return diag.FromErr(err)
 		}
 
 		// The copy endpoint only accepts a new alias, inheriting everything else (description,
-		// provider_id, ...) from the source flow, so re-fetch the created flow instead of relying
-		// on the partially-populated struct built from config.
-		authenticationFlow, err = keycloakClient.GetAuthenticationFlow(ctx, authenticationFlow.RealmId, id)
+		// provider_id, ...) from the source flow, and does not reliably return a Location header
+		// across Keycloak versions, so re-fetch the created flow by its new alias instead.
+		authenticationFlow, err = keycloakClient.GetAuthenticationFlowFromAlias(ctx, authenticationFlow.RealmId, authenticationFlow.Alias)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/provider/resource_keycloak_authentication_flow_test.go
+++ b/provider/resource_keycloak_authentication_flow_test.go
@@ -124,6 +124,32 @@ func TestAccKeycloakAuthenticationFlow_copyFrom(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakAuthenticationFlow_copyFromClientFlow(t *testing.T) {
+	t.Parallel()
+	authFlowAlias := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakAuthenticationFlowDestroy(),
+		Steps: []resource.TestStep{
+			{
+				// "clients" is a built-in flow whose provider_id is "client-flow", not the
+				// "basic-flow" default - this exercises provider_id correctly inheriting the
+				// copied flow's actual type instead of being forced/defaulted.
+				Config: testKeycloakAuthenticationFlow_copyFromClientFlow(authFlowAlias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakAuthenticationFlowExists("keycloak_authentication_flow.flow"),
+					resource.TestCheckResourceAttr("keycloak_authentication_flow.flow", "alias", authFlowAlias),
+					resource.TestCheckResourceAttr("keycloak_authentication_flow.flow", "provider_id", "client-flow"),
+					testAccCheckKeycloakAuthenticationFlowIsNotBuiltIn("keycloak_authentication_flow.flow"),
+					testAccCheckKeycloakAuthenticationFlowHasExecution("keycloak_authentication_flow.flow", "client-secret"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckKeycloakAuthenticationFlowIsNotBuiltIn(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		authenticationFlow, err := getAuthenticationFlowFromState(s, resourceName)
@@ -289,6 +315,20 @@ resource "keycloak_authentication_flow" "flow" {
 	realm_id  = data.keycloak_realm.realm.id
 	alias     = "%s"
 	copy_from = "browser"
+}
+	`, testAccRealm.Realm, alias)
+}
+
+func testKeycloakAuthenticationFlow_copyFromClientFlow(alias string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_authentication_flow" "flow" {
+	realm_id  = data.keycloak_realm.realm.id
+	alias     = "%s"
+	copy_from = "clients"
 }
 	`, testAccRealm.Realm, alias)
 }

--- a/provider/resource_keycloak_authentication_flow_test.go
+++ b/provider/resource_keycloak_authentication_flow_test.go
@@ -94,6 +94,73 @@ func TestAccKeycloakAuthenticationFlow_updateAuthenticationFlow(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakAuthenticationFlow_copyFrom(t *testing.T) {
+	t.Parallel()
+	authFlowAlias := acctest.RandomWithPrefix("tf-acc")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakAuthenticationFlowDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakAuthenticationFlow_copyFrom(authFlowAlias),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakAuthenticationFlowExists("keycloak_authentication_flow.flow"),
+					resource.TestCheckResourceAttr("keycloak_authentication_flow.flow", "alias", authFlowAlias),
+					resource.TestCheckResourceAttr("keycloak_authentication_flow.flow", "provider_id", "basic-flow"),
+					testAccCheckKeycloakAuthenticationFlowIsNotBuiltIn("keycloak_authentication_flow.flow"),
+					testAccCheckKeycloakAuthenticationFlowHasExecution("keycloak_authentication_flow.flow", "auth-cookie"),
+				),
+			},
+			{
+				ResourceName:            "keycloak_authentication_flow.flow",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdPrefix:     testAccRealm.Realm + "/",
+				ImportStateVerifyIgnore: []string{"copy_from"},
+			},
+		},
+	})
+}
+
+func testAccCheckKeycloakAuthenticationFlowIsNotBuiltIn(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		authenticationFlow, err := getAuthenticationFlowFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		if authenticationFlow.BuiltIn {
+			return fmt.Errorf("expected authentication flow with id %s to not be built-in", authenticationFlow.Id)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckKeycloakAuthenticationFlowHasExecution(resourceName, providerId string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		authenticationFlow, err := getAuthenticationFlowFromState(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		executions, err := keycloakClient.ListAuthenticationExecutions(testCtx, authenticationFlow.RealmId, authenticationFlow.Alias)
+		if err != nil {
+			return fmt.Errorf("error listing executions for authentication flow with id %s: %s", authenticationFlow.Id, err)
+		}
+
+		for _, execution := range executions {
+			if execution.ProviderId == providerId {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("expected authentication flow with id %s to have an execution with provider id %s", authenticationFlow.Id, providerId)
+	}
+}
+
 func TestAccKeycloakAuthenticationFlow_updateRealm(t *testing.T) {
 	t.Parallel()
 
@@ -208,6 +275,20 @@ data "keycloak_realm" "realm" {
 resource "keycloak_authentication_flow" "flow" {
 	realm_id = data.keycloak_realm.realm.id
 	alias    = "%s"
+}
+	`, testAccRealm.Realm, alias)
+}
+
+func testKeycloakAuthenticationFlow_copyFrom(alias string) string {
+	return fmt.Sprintf(`
+data "keycloak_realm" "realm" {
+	realm = "%s"
+}
+
+resource "keycloak_authentication_flow" "flow" {
+	realm_id  = data.keycloak_realm.realm.id
+	alias     = "%s"
+	copy_from = "browser"
 }
 	`, testAccRealm.Realm, alias)
 }


### PR DESCRIPTION
Closes #1687.

## Summary

Keycloak allows an existing execution's `requirement` to be changed directly on a built-in flow, but rejects any *structural* change - adding/removing an execution, or adding a subflow - with e.g. `"It is illegal to add execution to a built in flow"` (verified directly against the Admin REST API, see #1687 for the full breakdown).

- Adds a `copy_from` attribute to `keycloak_authentication_flow` that calls Keycloak's flow-copy endpoint (`POST .../flows/{alias}/copy`) instead of the normal create endpoint. The resulting flow is a full, independent copy of the source (built-in or not) that is not itself built-in, so it can be freely restructured, and can be bound in place of the original via `keycloak_authentication_bindings`.
- `provider_id` changes from a static `Default` to `Computed`, since a copy inherits its type from the source flow (e.g. the built-in `clients` flow uses `client-flow`, not `basic-flow`), which would otherwise cause a perpetual diff for anyone copying a non-`basic-flow` built-in flow.

## Test plan

- [x] `go build ./...` / `go vet ./...` / `gofmt -l` clean
- [x] New acceptance test `TestAccKeycloakAuthenticationFlow_copyFrom` (copies `browser`, asserts the result is not `builtIn`, asserts an execution was actually carried over, includes an import step)
- [x] Full `TestAccKeycloakAuthentication*` suite (27 tests) run locally against Keycloak 26.7.0 via `make local` - all pass, confirming no regression from the `provider_id` schema change
- [x] Manually verified against the raw Admin REST API that adding a new execution fails on `browser` itself but succeeds on a `copy_from` copy