### PR TITLE
fix: sort multivalue attribute values on keycloak_role and organization resource before diff

### DIFF
--- a/provider/diff_suppress_test.go
+++ b/provider/diff_suppress_test.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSuppressDiffForMultivalueAttributeOrder(t *testing.T) {
+	t.Parallel()
+
+	suppress := suppressDiffForMultivalueAttributeOrder()
+
+	tests := []struct {
+		name     string
+		old      string
+		new      string
+		expected bool
+	}{
+		{
+			name:     "identical single value",
+			old:      "role-1",
+			new:      "role-1",
+			expected: true,
+		},
+		{
+			name:     "different single value",
+			old:      "role-1",
+			new:      "role-2",
+			expected: false,
+		},
+		{
+			name:     "identical order",
+			old:      joinAttributeValues("role-1", "role-2", "role-3"),
+			new:      joinAttributeValues("role-1", "role-2", "role-3"),
+			expected: true,
+		},
+		{
+			name:     "same values in a different order",
+			old:      joinAttributeValues("role-3", "role-1", "role-2"),
+			new:      joinAttributeValues("role-1", "role-2", "role-3"),
+			expected: true,
+		},
+		{
+			name:     "value added",
+			old:      joinAttributeValues("role-1", "role-2"),
+			new:      joinAttributeValues("role-1", "role-2", "role-3"),
+			expected: false,
+		},
+		{
+			name:     "value removed",
+			old:      joinAttributeValues("role-1", "role-2", "role-3"),
+			new:      joinAttributeValues("role-1", "role-3"),
+			expected: false,
+		},
+		{
+			name:     "value replaced, count unchanged",
+			old:      joinAttributeValues("role-1", "role-2"),
+			new:      joinAttributeValues("role-1", "role-3"),
+			expected: false,
+		},
+		{
+			name:     "duplicates are significant",
+			old:      joinAttributeValues("role-1", "role-1"),
+			new:      joinAttributeValues("role-1", "role-2"),
+			expected: false,
+		},
+		{
+			name:     "reordered duplicates",
+			old:      joinAttributeValues("role-2", "role-1", "role-1"),
+			new:      joinAttributeValues("role-1", "role-1", "role-2"),
+			expected: true,
+		},
+		{
+			name:     "attribute created",
+			old:      "",
+			new:      joinAttributeValues("role-1", "role-2"),
+			expected: false,
+		},
+		{
+			name:     "attribute cleared",
+			old:      joinAttributeValues("role-1", "role-2"),
+			new:      "",
+			expected: false,
+		},
+		{
+			name:     "both empty",
+			old:      "",
+			new:      "",
+			expected: true,
+		},
+		// the DiffSuppressFunc of a TypeMap is also handed the flatmap element count
+		// key ("attributes.%"), which must keep its diff whenever the count changes
+		{
+			name:     "element count unchanged",
+			old:      "3",
+			new:      "3",
+			expected: true,
+		},
+		{
+			name:     "element count changed",
+			old:      "2",
+			new:      "3",
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if actual := suppress("attributes.some_attribute", test.old, test.new, nil); actual != test.expected {
+				t.Errorf("expected suppression of %q -> %q to be %t, but was %t", test.old, test.new, test.expected, actual)
+			}
+		})
+	}
+}
+
+func joinAttributeValues(values ...string) string {
+	return strings.Join(values, MULTIVALUE_ATTRIBUTE_SEPARATOR)
+}

--- a/provider/resource_keycloak_organization.go
+++ b/provider/resource_keycloak_organization.go
@@ -76,6 +76,8 @@ func resourceKeycloakOrganization() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Computed: true,
+				// ignore ordering of multi-valued attributes
+				DiffSuppressFunc: suppressDiffForMultivalueAttributeOrder(),
 			},
 		},
 	}

--- a/provider/resource_keycloak_organization_test.go
+++ b/provider/resource_keycloak_organization_test.go
@@ -156,6 +156,64 @@ func TestAccKeycloakOrganization_basicWithAttributes(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakOrganization_multiValuedAttributeNoDrift(t *testing.T) {
+	organizationName := acctest.RandomWithPrefix("tf-acc")
+	attributeName := acctest.RandomWithPrefix("tf-acc-tenant-roles")
+
+	orderedValues := []string{"role-1", "role-2", "role-3", "role-4", "role-5"}
+	attributeValue := strings.Join(orderedValues, MULTIVALUE_ATTRIBUTE_SEPARATOR)
+
+	resourceName := "keycloak_organization.organization"
+
+	var organization *keycloak.Organization
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakOrganizationDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakOrganization_attributes(organizationName, attributeName, attributeValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakOrganizationExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "attributes."+attributeName, attributeValue),
+					func(s *terraform.State) error {
+						var err error
+						organization, err = getOrganizationFromState(s, resourceName)
+						return err
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					// Keycloak won't persist a different order for a collection that already
+					// holds the same items, so the values have to be replaced with a dummy
+					// before they can be written back in a different order
+					fetchedOrganization, err := keycloakClient.GetOrganization(testCtx, organization.Realm, organization.Id)
+					if err != nil {
+						t.Fatal(err)
+					}
+					fetchedOrganization.Attributes = map[string][]string{
+						attributeName: {"dummy"},
+					}
+					if err = keycloakClient.UpdateOrganization(testCtx, fetchedOrganization); err != nil {
+						t.Fatal(err)
+					}
+					fetchedOrganization.Attributes = map[string][]string{
+						attributeName: {"role-3", "role-5", "role-1", "role-4", "role-2"},
+					}
+					if err = keycloakClient.UpdateOrganization(testCtx, fetchedOrganization); err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config:             testKeycloakOrganization_attributes(organizationName, attributeName, attributeValue),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func testAccCheckKeycloakOrganizationExists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		_, err := getOrganizationFromState(s, resourceName)

--- a/provider/resource_keycloak_role.go
+++ b/provider/resource_keycloak_role.go
@@ -54,6 +54,8 @@ func resourceKeycloakRole() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Computed: true,
+				// ignore ordering of multi-valued attributes
+				DiffSuppressFunc: suppressDiffForMultivalueAttributeOrder(),
 			},
 			"import": {
 				Type:     schema.TypeBool,

--- a/provider/resource_keycloak_role_test.go
+++ b/provider/resource_keycloak_role_test.go
@@ -305,6 +305,61 @@ func TestAccKeycloakRole_basicWithAttributes(t *testing.T) {
 	})
 }
 
+func TestAccKeycloakRole_multiValuedAttributeNoDrift(t *testing.T) {
+	t.Parallel()
+	roleName := acctest.RandomWithPrefix("tf-acc")
+	attributeName := acctest.RandomWithPrefix("tf-acc-tenant-roles")
+
+	orderedValues := []string{"role-1", "role-2", "role-3", "role-4", "role-5"}
+	attributeValue := strings.Join(orderedValues, MULTIVALUE_ATTRIBUTE_SEPARATOR)
+
+	resourceName := "keycloak_role.role"
+
+	var role keycloak.Role
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		CheckDestroy:             testAccCheckKeycloakRoleDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKeycloakRole_basicWithAttributes(roleName, attributeName, attributeValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeycloakRoleExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "attributes."+attributeName, attributeValue),
+					testAccCheckKeycloakRoleFetch(resourceName, &role),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Keycloak won't persist a different order for a collection that already
+					// holds the same items, so the values have to be replaced with a dummy
+					// before they can be written back in a different order
+					fetchedRole, err := keycloakClient.GetRole(testCtx, role.RealmId, role.Id)
+					if err != nil {
+						t.Fatal(err)
+					}
+					fetchedRole.Attributes = map[string][]string{
+						attributeName: {"dummy"},
+					}
+					if err = keycloakClient.UpdateRole(testCtx, fetchedRole); err != nil {
+						t.Fatal(err)
+					}
+					fetchedRole.Attributes = map[string][]string{
+						attributeName: {"role-3", "role-5", "role-1", "role-4", "role-2"},
+					}
+					if err = keycloakClient.UpdateRole(testCtx, fetchedRole); err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config:             testKeycloakRole_basicWithAttributes(roleName, attributeName, attributeValue),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccKeycloakRole_importWithAttributes(t *testing.T) {
 	t.Parallel()
 	roleName := acctest.RandomWithPrefix("tf-acc")


### PR DESCRIPTION
Inspired by #1520
Fixes #859 

---

AI Disclaimer: Change prepared with Claude Opus 5

I confirmed manually that with this change `apply` no longer displays diffs caused by order change
